### PR TITLE
feat(tui): CheckTree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,6 +2197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,11 +2630,12 @@ dependencies = [
  "mecomp-storage",
  "mecomp-workspace-hack",
  "one-or-many",
+ "pretty_assertions",
  "ratatui",
  "tarpc",
  "tokio",
  "tokio-stream",
- "tui-tree-widget",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3833,19 +3843,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
 dependencies = [
  "bitflags 2.5.0",
  "cassowary",
  "compact_str",
  "crossterm",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "stability",
  "strum",
+ "strum_macros",
  "time",
  "unicode-segmentation",
  "unicode-truncate",
@@ -5743,16 +5754,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tui-tree-widget"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6201de8ad8d88cb6cac4cfe3436d9a1ea31c0732a7aec4c2cc3b23186ad7dcc"
-dependencies = [
- "ratatui",
- "unicode-width",
-]
 
 [[package]]
 name = "typenum"

--- a/TODO.md
+++ b/TODO.md
@@ -70,34 +70,33 @@
 
 - [x] Implement basic TUI
 - [x] CheckTree widget: a tree/list that allows for multiple items to be selected
-  - [ ] allow for multiple items to be selected and added to the queue, a playlist, or used to start a radio
-  - [ ] function to get the selected items
-- [ ] add confirmation dialogues for potentially destructive actions (e.g. deleting a playlist, initiating a rescan, etc.)
-- [ ] Implement view pages for the following:
-  - [ ] search results
+  - [x] allow for multiple items to be selected and added to the queue, a playlist, or used to start a radio
+  - [x] function to get the selected items
+- [x] Implement view pages for the following:
+  - [x] search results
     - [x] show the results of a search
     - [x] pressing enter on a result will take you to the appropriate view page for that result
-    - [ ] use CheckTree widget instead of Tree
-  - [ ] radio results
+    - [x] use CheckTree widget instead of Tree
+  - [x] radio results
     - [x] show the results of a radio search
     - [x] keybind to add to queue
     - [x] keybind to add to a playlist
-    - [ ] use CheckTree widget instead of Tree
-  - [ ] albums
+    - [x] use CheckTree widget instead of Tree
+  - [x] albums
     - [x] display all albums
     - [x] be able to "enter" an to go to the album view page
     - [x] ability to sort by name, artist, year, etc.
-    - [ ] use CheckTree widget instead of Tree
-  - [ ] artists
+    - [x] use CheckTree widget instead of Tree
+  - [x] artists
     - [x] display all artists
     - [x] be able to "enter" an artist to go to the artist view page
     - [x] ability to sort by name, etc.
-    - [ ] use CheckTree widget instead of Tree
-  - [ ] songs
+    - [x] use CheckTree widget instead of Tree
+  - [x] songs
     - [x] display all songs
     - [x] be able to "enter" a song to go to the song view page
     - [x] ability to sort by name, artist, album, year, etc.
-    - [ ] use CheckTree widget instead of Tree
+    - [x] use CheckTree widget instead of Tree
   - [x] playlists
     - [x] display all playlists
     - [x] ability to sort by name, etc.
@@ -107,33 +106,37 @@
   - [x] collections
     - [x] display all collections
     - [x] be able to "enter" a collection to go to the collection view page
-  - [ ] a single album
+  - [x] a single album
     - [x] show info about the album, including all the songs contained
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
-    - [ ] use CheckTree widget instead of Tree
-  - [ ] a single artist
+    - [x] use CheckTree widget instead of Tree
+  - [x] a single artist
     - [x] show info about the artist, including all the albums and songs by the artist
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
-    - [ ] use CheckTree widget instead of Tree
+    - [x] use CheckTree widget instead of Tree
   - [x] a single song
     - [x] show information about the song
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
+    - [x] use CheckTree widget instead of Tree
   - [x] a single playlist
     - [x] show the playlist's name and contents
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
     - [x] keybind to remove a song from the playlist
-  - [ ] a single collection
+    - [x] use CheckTree widget instead of Tree
+  - [x] a single collection
     - [x] show the collection's contents
     - [x] keybind to add to queue
-    - [ ] keybind to freeze into a playlist
+    - [x] use CheckTree widget instead of Tree
+- [ ] add confirmation dialogues for potentially destructive actions (e.g. deleting a playlist, initiating a rescan, etc.)
+- [ ] keybind to freeze a collection into a playlist
 - [ ] at startup, check if the daemon is running, and if it isn't then start it in a detached process
 
 ### MECOMP-GUI

--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@
 ### MECOMP-TUI
 
 - [x] Implement basic TUI
-- [ ] ThingTree widget: a tree/list that allows for multiple items to be selected
+- [x] CheckTree widget: a tree/list that allows for multiple items to be selected
   - [ ] allow for multiple items to be selected and added to the queue, a playlist, or used to start a radio
   - [ ] function to get the selected items
 - [ ] add confirmation dialogues for potentially destructive actions (e.g. deleting a playlist, initiating a rescan, etc.)
@@ -77,27 +77,27 @@
   - [ ] search results
     - [x] show the results of a search
     - [x] pressing enter on a result will take you to the appropriate view page for that result
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [ ] radio results
     - [x] show the results of a radio search
     - [x] keybind to add to queue
     - [x] keybind to add to a playlist
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [ ] albums
     - [x] display all albums
     - [x] be able to "enter" an to go to the album view page
     - [x] ability to sort by name, artist, year, etc.
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [ ] artists
     - [x] display all artists
     - [x] be able to "enter" an artist to go to the artist view page
     - [x] ability to sort by name, etc.
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [ ] songs
     - [x] display all songs
     - [x] be able to "enter" a song to go to the song view page
     - [x] ability to sort by name, artist, album, year, etc.
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [x] playlists
     - [x] display all playlists
     - [x] ability to sort by name, etc.
@@ -112,13 +112,13 @@
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [ ] a single artist
     - [x] show info about the artist, including all the albums and songs by the artist
     - [x] keybind to add to queue
     - [x] keybind to start a radio
     - [x] keybind to add to a playlist
-    - [ ] use ThingTree widget instead of Tree
+    - [ ] use CheckTree widget instead of Tree
   - [x] a single song
     - [x] show information about the song
     - [x] keybind to add to queue

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -56,8 +56,12 @@ pub struct MusicPlayerServer {
 
 impl MusicPlayerServer {
     #[must_use]
-    pub fn new(addr: SocketAddr, db: Arc<Surreal<Db>>, settings: Arc<Settings>) -> Self {
-        let audio_kernel = AudioKernelSender::start();
+    pub fn new(
+        addr: SocketAddr,
+        db: Arc<Surreal<Db>>,
+        settings: Arc<Settings>,
+        audio_kernel: Arc<AudioKernelSender>,
+    ) -> Self {
         Self {
             addr,
             db,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -13,6 +13,7 @@ use tarpc::{
 };
 //-------------------------------------------------------------------------------- MECOMP libraries
 use mecomp_core::{
+    audio::AudioKernelSender,
     logger::{init_logger, init_tracing},
     rpc::MusicPlayer as _,
 };
@@ -70,6 +71,9 @@ pub async fn start_daemon(settings: Settings, db_dir: std::path::PathBuf) -> any
         settings.daemon.genre_separator.clone(),
     )?;
 
+    // Start the audio kernel.
+    let audio_kernel = AudioKernelSender::start();
+
     // Start the RPC server.
     let server_addr = (IpAddr::V4(Ipv4Addr::LOCALHOST), settings.daemon.rpc_port);
 
@@ -90,6 +94,7 @@ pub async fn start_daemon(settings: Settings, db_dir: std::path::PathBuf) -> any
                 channel.transport().peer_addr().unwrap(),
                 db.clone(),
                 settings.clone(),
+                audio_kernel.clone(),
             );
             channel.execute(server.serve()).for_each(spawn)
         })

--- a/daemon/src/services/library.rs
+++ b/daemon/src/services/library.rs
@@ -586,7 +586,7 @@ mod tests {
         let db = init_test_database().await.unwrap();
         let settings = ReclusterSettings {
             gap_statistic_reference_datasets: 50,
-            max_clusters: 12,
+            max_clusters: 16,
             max_iterations: 30,
         };
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -14,9 +14,8 @@ license.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-ratatui = { version = "0.26.3", features = ["all-widgets"] }
+ratatui = { version = "0.27.0", features = ["all-widgets"] }
 # log.workspace = true
-tui-tree-widget = "0.20.0"
 tarpc.workspace = true
 tokio = { workspace = true, features = ["signal"] }
 tokio-stream = "0.1.15"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -19,9 +19,13 @@ ratatui = { version = "0.27.0", features = ["all-widgets"] }
 tarpc.workspace = true
 tokio = { workspace = true, features = ["signal"] }
 tokio-stream = "0.1.15"
+unicode-width = "0.1.13"
 
 # MECOMP dependencies
 one-or-many.workspace = true
 mecomp-core = { workspace = true, features = ["rpc"] }
 mecomp-storage = { workspace = true, features = ["serde"] }
 mecomp-workspace-hack = { version = "0.1", path = "../mecomp-workspace-hack" }
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/tui/src/ui/app.rs
+++ b/tui/src/ui/app.rs
@@ -5,7 +5,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Style, Stylize},
     text::Span,
     widgets::Block,
@@ -222,8 +222,8 @@ impl Component for App {
     }
 }
 
-impl ComponentRender<()> for App {
-    fn render(&self, frame: &mut Frame, _props: ()) {
+impl ComponentRender<Rect> for App {
+    fn render_border(&self, frame: &mut Frame, area: Rect) -> Rect {
         let block = Block::bordered()
             .title_top(Span::styled(
                 "MECOMP",
@@ -235,9 +235,12 @@ impl ComponentRender<()> for App {
             ))
             .border_style(Style::default().fg(APP_BORDER.into()))
             .style(Style::default().fg(TEXT_NORMAL.into()));
-        let area = block.inner(frame.size());
-        frame.render_widget(block, frame.size());
+        let app_area = block.inner(area);
+        frame.render_widget(block, area);
+        app_area
+    }
 
+    fn render_content(&self, frame: &mut Frame, area: Rect) {
         let [main_views_area, control_panel_area] = *Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(10), Constraint::Length(4)].as_ref())

--- a/tui/src/ui/app.rs
+++ b/tui/src/ui/app.rs
@@ -177,6 +177,11 @@ impl Component for App {
             queuebar: self.queuebar.move_with_state(state),
             control_panel: self.control_panel.move_with_state(state),
             content_view: self.content_view.move_with_state(state),
+            popup: self.popup.map(|popup| {
+                let mut popup = popup;
+                popup.update_with_state(state);
+                popup
+            }),
             ..self
         }
     }

--- a/tui/src/ui/colors.rs
+++ b/tui/src/ui/colors.rs
@@ -15,8 +15,8 @@ pub const TEXT_HIGHLIGHT: material::HexColor = material::RED_600;
 pub const TEXT_HIGHLIGHT_ALT: material::HexColor = material::RED_200;
 
 // gauge colors, such as song progress bar
-pub const GAUGE_FOREGROUND: material::HexColor = material::WHITE;
-pub const GAUGE_BACKGROUND: material::HexColor = material::BLACK;
+pub const GAUGE_FILLED: material::HexColor = material::WHITE;
+pub const GAUGE_UNFILLED: material::HexColor = material::BLACK;
 
 pub mod material {
     //! # Material Design Colors

--- a/tui/src/ui/components/content_view/mod.rs
+++ b/tui/src/ui/components/content_view/mod.rs
@@ -191,7 +191,12 @@ impl Component for ContentView {
 }
 
 impl ComponentRender<RenderProps> for ContentView {
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    /// we defer all border rendering to the active view
+    fn render_border(&self, _: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
+        props
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
         match &self.props.active_view {
             ActiveView::None => self.none_view.render(frame, props),
             ActiveView::Search => self.search_view.render(frame, props),

--- a/tui/src/ui/components/content_view/views/album.rs
+++ b/tui/src/ui/components/content_view/views/album.rs
@@ -28,7 +28,9 @@ use crate::{
 
 use super::{
     checktree_utils::{
-        create_album_tree_leaf, create_artist_tree_item, create_song_tree_item,
+        construct_add_to_playlist_action, construct_add_to_queue_action,
+        construct_start_radio_action, create_album_tree_leaf, create_artist_tree_item,
+        create_song_tree_item, get_checked_things_from_tree_state,
         get_selected_things_from_tree_state,
     },
     AlbumViewProps, RADIO_SIZE,
@@ -105,35 +107,31 @@ impl Component for AlbumView {
                     }
                 }
             }
-            // Add album to queue
+            // if there are checked items, add them to the queue, otherwise send the whole ablum to the queue
             KeyCode::Char('q') => {
-                if let Some(props) = &self.props {
-                    self.action_tx
-                        .send(Action::Audio(AudioAction::Queue(QueueAction::Add(vec![
-                            props.id.clone(),
-                        ]))))
-                        .unwrap();
+                if let Some(action) = construct_add_to_queue_action(
+                    get_checked_things_from_tree_state(&self.tree_state.lock().unwrap()),
+                    self.props.as_ref().map(|p| &p.id),
+                ) {
+                    self.action_tx.send(action).unwrap();
                 }
             }
-            // Start radio from album
+            // if there are checked items, start radio from checked items, otherwise start radio from album
             KeyCode::Char('r') => {
-                if let Some(props) = &self.props {
-                    self.action_tx
-                        .send(Action::SetCurrentView(ActiveView::Radio(
-                            vec![props.id.clone()],
-                            RADIO_SIZE,
-                        )))
-                        .unwrap();
+                if let Some(action) = construct_start_radio_action(
+                    get_checked_things_from_tree_state(&self.tree_state.lock().unwrap()),
+                    self.props.as_ref().map(|p| &p.id),
+                ) {
+                    self.action_tx.send(action).unwrap();
                 }
             }
-            // add album to playlist
+            // if there are checked items, add them to playlist, otherwise add the whole album to playlist
             KeyCode::Char('p') => {
-                if let Some(props) = &self.props {
-                    self.action_tx
-                        .send(Action::Popup(PopupAction::Open(PopupType::Playlist(vec![
-                            props.id.clone(),
-                        ]))))
-                        .unwrap();
+                if let Some(action) = construct_add_to_playlist_action(
+                    get_checked_things_from_tree_state(&self.tree_state.lock().unwrap()),
+                    self.props.as_ref().map(|p| &p.id),
+                ) {
+                    self.action_tx.send(action).unwrap();
                 }
             }
             _ => {}
@@ -213,6 +211,27 @@ impl ComponentRender<RenderProps> for AlbumView {
             let border = Block::default()
                 .borders(Borders::TOP)
                 .title_top("q: add to queue | r: start radio | p: add to playlist")
+                .border_style(border_style);
+            frame.render_widget(&border, content_area);
+            let content_area = border.inner(content_area);
+
+            // draw an additional border around the content area to indicate whether operations will be performed on the entire item, or just the checked items
+            let border = Block::default()
+                .borders(Borders::TOP)
+                .title_top(Line::from(vec![
+                    Span::raw("Performing operations on "),
+                    Span::raw(
+                        if get_checked_things_from_tree_state(&self.tree_state.lock().unwrap())
+                            .is_empty()
+                        {
+                            "entire album"
+                        } else {
+                            "checked items"
+                        },
+                    )
+                    .fg(TEXT_HIGHLIGHT),
+                ]))
+                .italic()
                 .border_style(border_style);
             frame.render_widget(&border, content_area);
             border.inner(content_area)
@@ -403,6 +422,37 @@ impl Component for LibraryAlbumsView {
                     }
                 }
             }
+            // when there are checked items, "q" will send the checked items to the queue
+            KeyCode::Char('q') => {
+                let things = get_checked_things_from_tree_state(&self.tree_state.lock().unwrap());
+                if !things.is_empty() {
+                    self.action_tx
+                        .send(Action::Audio(AudioAction::Queue(QueueAction::Add(things))))
+                        .unwrap();
+                }
+            }
+            // when there are checked items, "r" will start a radio with the checked items
+            KeyCode::Char('r') => {
+                let things = get_checked_things_from_tree_state(&self.tree_state.lock().unwrap());
+                if !things.is_empty() {
+                    self.action_tx
+                        .send(Action::SetCurrentView(ActiveView::Radio(
+                            things, RADIO_SIZE,
+                        )))
+                        .unwrap();
+                }
+            }
+            // when there are checked items, "p" will send the checked items to the playlist
+            KeyCode::Char('p') => {
+                let things = get_checked_things_from_tree_state(&self.tree_state.lock().unwrap());
+                if !things.is_empty() {
+                    self.action_tx
+                        .send(Action::Popup(PopupAction::Open(PopupType::Playlist(
+                            things,
+                        ))))
+                        .unwrap();
+                }
+            }
             // Change sort mode
             KeyCode::Char('s') => {
                 self.props.sort_mode = self.props.sort_mode.next();
@@ -440,6 +490,13 @@ impl ComponentRender<RenderProps> for LibraryAlbumsView {
         // draw an additional border around the content area to display additional instructions
         let border = Block::default()
             .borders(Borders::TOP | Borders::BOTTOM)
+            .title_top(
+                if get_checked_things_from_tree_state(&self.tree_state.lock().unwrap()).is_empty() {
+                    ""
+                } else {
+                    "q: add to queue | r: start radio | p: add to playlist "
+                },
+            )
             .title_bottom("s/S: change sort")
             .border_style(border_style);
         let area = border.inner(content_area);

--- a/tui/src/ui/components/content_view/views/album.rs
+++ b/tui/src/ui/components/content_view/views/album.rs
@@ -94,9 +94,7 @@ impl Component for AlbumView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();
@@ -376,9 +374,7 @@ impl Component for LibraryAlbumsView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -94,9 +94,7 @@ impl Component for ArtistView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();
@@ -346,9 +344,7 @@ impl Component for LibraryArtistsView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -7,7 +7,7 @@ use mecomp_core::format_duration;
 use mecomp_storage::db::schemas::artist::Artist;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Modifier, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation},
 };
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     state::action::{Action, AudioAction, PopupAction, QueueAction},
     ui::{
-        colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT},
+        colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT, TEXT_NORMAL},
         components::{content_view::ActiveView, Component, ComponentRender, RenderProps},
         widgets::{
             popups::PopupType,
@@ -27,7 +27,6 @@ use crate::{
 };
 
 use super::{
-    none::NoneView,
     checktree_utils::{
         create_album_tree_item, create_artist_tree_leaf, create_song_tree_item,
         get_selected_things_from_tree_state,
@@ -143,31 +142,27 @@ impl Component for ArtistView {
 }
 
 impl ComponentRender<RenderProps> for ArtistView {
-    #[allow(clippy::too_many_lines)]
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
             Style::default().fg(BORDER_UNFOCUSED.into())
         };
 
-        if let Some(state) = &self.props {
-            let block = Block::bordered()
+        // draw borders and get content area
+        let area = if let Some(state) = &self.props {
+            let border = Block::bordered()
                 .title_top("Artist View")
-                .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check")
+                .title_bottom(" \u{23CE} : Open | ←/↑/↓/→: Navigate | \u{2423} Check")
                 .border_style(border_style);
-            let block_area = block.inner(props.area);
-            frame.render_widget(block, props.area);
+            let content_area = border.inner(props.area);
+            frame.render_widget(border, props.area);
 
-            // create list to hold artist albums and songs
-            let album_tree = create_album_tree_item(&state.albums).unwrap();
-            let song_tree = create_song_tree_item(&state.songs).unwrap();
-            let items = &[album_tree, song_tree];
-
-            let [top, bottom] = *Layout::default()
+            // split the area to make room for the artist info
+            let [info_area, content_area] = *Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(3), Constraint::Min(4)])
-                .split(block_area)
+                .split(content_area)
             else {
                 panic!("Failed to split artist view area")
             };
@@ -197,28 +192,52 @@ impl ComponentRender<RenderProps> for ArtistView {
                         ),
                     ]),
                 ])
-                .block(
-                    Block::new()
-                        .borders(Borders::BOTTOM)
-                        .title_bottom("q: add to queue | r: start radio | p: add to playlist")
-                        .border_style(border_style),
-                )
                 .alignment(Alignment::Center),
-                top,
+                info_area,
             );
+
+            // draw an additional border around the content area to display additional instructions
+            let border = Block::default()
+                .borders(Borders::TOP)
+                .title_top("q: add to queue | r: start radio | p: add to playlist")
+                .border_style(border_style);
+            frame.render_widget(&border, content_area);
+            border.inner(content_area)
+        } else {
+            let border = Block::bordered()
+                .title_top("Artist View")
+                .border_style(border_style);
+            frame.render_widget(&border, props.area);
+            border.inner(props.area)
+        };
+
+        RenderProps { area, ..props }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+        if let Some(state) = &self.props {
+            // create list to hold artist albums and songs
+            let album_tree = create_album_tree_item(&state.albums).unwrap();
+            let song_tree = create_song_tree_item(&state.songs).unwrap();
+            let items = &[album_tree, song_tree];
 
             // render the artist artists / album
             frame.render_stateful_widget(
-                CheckTree::new(items).unwrap().highlight_style(
-                    Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                bottom,
+                CheckTree::new(items)
+                    .unwrap()
+                    .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold()),
+                props.area,
                 &mut self.tree_state.lock().unwrap(),
             );
         } else {
-            NoneView.render(frame, props);
+            let text = "No active artist";
+
+            frame.render_widget(
+                Line::from(text)
+                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .alignment(Alignment::Center),
+                props.area,
+            );
         }
     }
 }
@@ -369,32 +388,38 @@ impl Component for LibraryArtistsView {
 }
 
 impl ComponentRender<RenderProps> for LibraryArtistsView {
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
             Style::default().fg(BORDER_UNFOCUSED.into())
         };
 
-        let block = Block::bordered()
+        // draw primary border
+        let border = Block::bordered()
             .title_top(Line::from(vec![
                 Span::styled("Library Artists".to_string(), Style::default().bold()),
                 Span::raw(" sorted by: "),
                 Span::styled(self.props.sort_mode.to_string(), Style::default().italic()),
             ]))
-            .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check | s/S: change sort")
+            .title_bottom(" \u{23CE} : Open | ←/↑/↓/→: Navigate | \u{2423} Check")
             .border_style(border_style);
-        let block_area = block.inner(props.area);
-        frame.render_widget(block, props.area);
+        let content_area = border.inner(props.area);
+        frame.render_widget(border, props.area);
 
-        let [top, bottom] = *Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(1), Constraint::Min(4)])
-            .split(block_area)
-        else {
-            panic!("Failed to split library artists view area");
-        };
+        // draw an additional border around the content area to display additional instructions
+        let border = Block::default()
+            .borders(Borders::TOP | Borders::BOTTOM)
+            .title_bottom("s/S: change sort")
+            .border_style(border_style);
+        let area = border.inner(content_area);
+        frame.render_widget(border, content_area);
 
+        RenderProps { area, ..props }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+        // create a tree for the artists
         let items = self
             .props
             .artists
@@ -402,23 +427,13 @@ impl ComponentRender<RenderProps> for LibraryArtistsView {
             .map(|artist| create_artist_tree_leaf(artist))
             .collect::<Vec<_>>();
 
-        frame.render_widget(
-            Block::new()
-                .borders(Borders::BOTTOM)
-                .border_style(border_style),
-            top,
-        );
-
+        // render the artists
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(
-                    Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
-                        .add_modifier(Modifier::BOLD),
-                )
+                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
-            bottom,
+            props.area,
             &mut self.tree_state.lock().unwrap(),
         );
     }

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -12,21 +12,23 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation},
 };
 use tokio::sync::mpsc::UnboundedSender;
-use tui_tree_widget::{Tree, TreeState};
 
 use crate::{
     state::action::{Action, AudioAction, PopupAction, QueueAction},
     ui::{
         colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT},
         components::{content_view::ActiveView, Component, ComponentRender, RenderProps},
-        widgets::popups::PopupType,
+        widgets::{
+            popups::PopupType,
+            tree::{state::CheckTreeState, CheckTree},
+        },
         AppState,
     },
 };
 
 use super::{
     none::NoneView,
-    utils::{
+    checktree_utils::{
         create_album_tree_item, create_artist_tree_leaf, create_song_tree_item,
         get_selected_things_from_tree_state,
     },
@@ -40,7 +42,7 @@ pub struct ArtistView {
     /// Mapped Props from state
     pub props: Option<ArtistViewProps>,
     /// tree state
-    tree_state: Mutex<TreeState<String>>,
+    tree_state: Mutex<CheckTreeState<String>>,
 }
 
 impl Component for ArtistView {
@@ -51,7 +53,7 @@ impl Component for ArtistView {
         Self {
             action_tx,
             props: state.additional_view_data.artist.clone(),
-            tree_state: Mutex::new(TreeState::default()),
+            tree_state: Mutex::new(CheckTreeState::default()),
         }
     }
 
@@ -87,6 +89,9 @@ impl Component for ArtistView {
             }
             KeyCode::Right => {
                 self.tree_state.lock().unwrap().key_right();
+            }
+            KeyCode::Char(' ') => {
+                self.tree_state.lock().unwrap().key_space();
             }
             // Enter key opens selected view
             KeyCode::Enter => {
@@ -149,7 +154,7 @@ impl ComponentRender<RenderProps> for ArtistView {
         if let Some(state) = &self.props {
             let block = Block::bordered()
                 .title_top("Artist View")
-                .title_bottom("Enter: Open | ←/↑/↓/→: Navigate")
+                .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check")
                 .border_style(border_style);
             let block_area = block.inner(props.area);
             frame.render_widget(block, props.area);
@@ -204,16 +209,11 @@ impl ComponentRender<RenderProps> for ArtistView {
 
             // render the artist artists / album
             frame.render_stateful_widget(
-                Tree::new(items)
-                    .unwrap()
-                    .highlight_style(
-                        Style::default()
-                            .fg(TEXT_HIGHLIGHT.into())
-                            .add_modifier(Modifier::BOLD),
-                    )
-                    .node_closed_symbol("▸")
-                    .node_open_symbol("▾")
-                    .node_no_children_symbol("▪"),
+                CheckTree::new(items).unwrap().highlight_style(
+                    Style::default()
+                        .fg(TEXT_HIGHLIGHT.into())
+                        .add_modifier(Modifier::BOLD),
+                ),
                 bottom,
                 &mut self.tree_state.lock().unwrap(),
             );
@@ -229,7 +229,7 @@ pub struct LibraryArtistsView {
     /// Mapped Props from state
     props: Props,
     /// tree state
-    tree_state: Mutex<TreeState<String>>,
+    tree_state: Mutex<CheckTreeState<String>>,
 }
 
 struct Props {
@@ -289,7 +289,7 @@ impl Component for LibraryArtistsView {
         Self {
             action_tx,
             props: Props { artists, sort_mode },
-            tree_state: Mutex::new(TreeState::default()),
+            tree_state: Mutex::new(CheckTreeState::default()),
         }
     }
 
@@ -338,6 +338,9 @@ impl Component for LibraryArtistsView {
             KeyCode::Right => {
                 self.tree_state.lock().unwrap().key_right();
             }
+            KeyCode::Char(' ') => {
+                self.tree_state.lock().unwrap().key_space();
+            }
             // Enter key opens selected view
             KeyCode::Enter => {
                 if self.tree_state.lock().unwrap().toggle_selected() {
@@ -379,7 +382,7 @@ impl ComponentRender<RenderProps> for LibraryArtistsView {
                 Span::raw(" sorted by: "),
                 Span::styled(self.props.sort_mode.to_string(), Style::default().italic()),
             ]))
-            .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | s/S: change sort")
+            .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check | s/S: change sort")
             .border_style(border_style);
         let block_area = block.inner(props.area);
         frame.render_widget(block, props.area);
@@ -407,16 +410,13 @@ impl ComponentRender<RenderProps> for LibraryArtistsView {
         );
 
         frame.render_stateful_widget(
-            Tree::new(&items)
+            CheckTree::new(&items)
                 .unwrap()
                 .highlight_style(
                     Style::default()
                         .fg(TEXT_HIGHLIGHT.into())
                         .add_modifier(Modifier::BOLD),
                 )
-                .node_closed_symbol("▸")
-                .node_open_symbol("▾")
-                .node_no_children_symbol("▪")
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             bottom,
             &mut self.tree_state.lock().unwrap(),

--- a/tui/src/ui/components/content_view/views/collection.rs
+++ b/tui/src/ui/components/content_view/views/collection.rs
@@ -129,9 +129,7 @@ impl Component for CollectionView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();
@@ -380,9 +378,7 @@ impl Component for LibraryCollectionsView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/collection.rs
+++ b/tui/src/ui/components/content_view/views/collection.rs
@@ -216,7 +216,7 @@ impl ComponentRender<RenderProps> for CollectionView {
                 info_area,
             );
 
-            // draw an additional border around the content area to display additionaly instructions
+            // draw an additional border around the content area to display additionally instructions
             let border = Block::new()
                 .borders(Borders::TOP | Borders::BOTTOM)
                 .title_top("q: add to queue | p: add to playlist")

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -89,8 +89,7 @@ pub mod checktree_utils {
         tree_state
             .selected()
             .iter()
-            .filter_map(|id| id.parse::<Thing>().ok())
-            .next()
+            .find_map(|id| id.parse::<Thing>().ok())
     }
 
     fn create_dummy_leaf() -> CheckTreeItem<'static, String> {

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -72,7 +72,7 @@ pub struct RadioViewProps {
     pub songs: Box<[Song]>,
 }
 
-pub mod utils {
+pub mod checktree_utils {
     use mecomp_storage::db::schemas::{
         album::Album, artist::Artist, collection::Collection, playlist::Playlist, song::Song, Thing,
     };
@@ -80,9 +80,12 @@ pub mod utils {
         style::{Style, Stylize},
         text::{Line, Span},
     };
-    use tui_tree_widget::{TreeItem, TreeState};
 
-    pub fn get_selected_things_from_tree_state(tree_state: &TreeState<String>) -> Option<Thing> {
+    use crate::ui::widgets::tree::{item::CheckTreeItem, state::CheckTreeState};
+
+    pub fn get_selected_things_from_tree_state(
+        tree_state: &CheckTreeState<String>,
+    ) -> Option<Thing> {
         tree_state
             .selected()
             .iter()
@@ -90,22 +93,32 @@ pub mod utils {
             .next()
     }
 
-    pub fn create_album_tree_item(albums: &[Album]) -> Result<TreeItem<String>, std::io::Error> {
-        TreeItem::new(
+    fn create_dummy_leaf() -> CheckTreeItem<'static, String> {
+        CheckTreeItem::new_leaf("dummy".to_string(), "")
+    }
+
+    pub fn create_album_tree_item(
+        albums: &[Album],
+    ) -> Result<CheckTreeItem<String>, std::io::Error> {
+        let mut item = CheckTreeItem::new(
             "Albums".to_string(),
             format!("Albums ({}):", albums.len()),
             albums
                 .iter()
                 .map(|album| create_album_tree_leaf(album, None))
                 .collect(),
-        )
+        )?;
+        if item.children().is_empty() {
+            item.add_child(create_dummy_leaf()).unwrap();
+        }
+        Ok(item)
     }
 
     pub fn create_album_tree_leaf<'a>(
         album: &Album,
         prefix: Option<Span<'a>>,
-    ) -> TreeItem<'a, String> {
-        TreeItem::new_leaf(
+    ) -> CheckTreeItem<'a, String> {
+        CheckTreeItem::new_leaf(
             album.id.to_string(),
             Line::from(vec![
                 prefix.unwrap_or_default(),
@@ -124,19 +137,25 @@ pub mod utils {
         )
     }
 
-    pub fn create_artist_tree_item(artists: &[Artist]) -> Result<TreeItem<String>, std::io::Error> {
-        TreeItem::new(
+    pub fn create_artist_tree_item(
+        artists: &[Artist],
+    ) -> Result<CheckTreeItem<String>, std::io::Error> {
+        let mut item = CheckTreeItem::new(
             "Artists".to_string(),
             format!("Artists ({}):", artists.len()),
             artists
                 .iter()
                 .map(|artist| create_artist_tree_leaf(artist))
                 .collect(),
-        )
+        )?;
+        if item.children().is_empty() {
+            item.add_child(create_dummy_leaf()).unwrap();
+        }
+        Ok(item)
     }
 
-    pub fn create_artist_tree_leaf(artist: &Artist) -> TreeItem<String> {
-        TreeItem::new_leaf(
+    pub fn create_artist_tree_leaf(artist: &Artist) -> CheckTreeItem<String> {
+        CheckTreeItem::new_leaf(
             artist.id.to_string(),
             Line::from(vec![Span::styled(
                 artist.name.to_string(),
@@ -145,8 +164,8 @@ pub mod utils {
         )
     }
 
-    pub fn create_collection_tree_leaf(collection: &Collection) -> TreeItem<String> {
-        TreeItem::new_leaf(
+    pub fn create_collection_tree_leaf(collection: &Collection) -> CheckTreeItem<String> {
+        CheckTreeItem::new_leaf(
             collection.id.to_string(),
             Line::from(vec![Span::styled(
                 collection.name.to_string(),
@@ -155,8 +174,8 @@ pub mod utils {
         )
     }
 
-    pub fn create_playlist_tree_leaf(playlist: &Playlist) -> TreeItem<String> {
-        TreeItem::new_leaf(
+    pub fn create_playlist_tree_leaf(playlist: &Playlist) -> CheckTreeItem<String> {
+        CheckTreeItem::new_leaf(
             playlist.id.to_string(),
             Line::from(vec![Span::styled(
                 playlist.name.to_string(),
@@ -165,19 +184,23 @@ pub mod utils {
         )
     }
 
-    pub fn create_song_tree_item(songs: &[Song]) -> Result<TreeItem<String>, std::io::Error> {
-        TreeItem::new(
+    pub fn create_song_tree_item(songs: &[Song]) -> Result<CheckTreeItem<String>, std::io::Error> {
+        let mut item = CheckTreeItem::new(
             "Songs".to_string(),
             format!("Songs ({}):", songs.len()),
             songs
                 .iter()
                 .map(|song| create_song_tree_leaf(song))
                 .collect(),
-        )
+        )?;
+        if item.children().is_empty() {
+            item.add_child(create_dummy_leaf()).unwrap();
+        }
+        Ok(item)
     }
 
-    pub fn create_song_tree_leaf(song: &Song) -> TreeItem<String> {
-        TreeItem::new_leaf(
+    pub fn create_song_tree_leaf(song: &Song) -> CheckTreeItem<String> {
+        CheckTreeItem::new_leaf(
             song.id.to_string(),
             Line::from(vec![
                 Span::styled(song.title.to_string(), Style::default().bold()),

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -81,8 +81,90 @@ pub mod checktree_utils {
         text::{Line, Span},
     };
 
-    use crate::ui::widgets::tree::{item::CheckTreeItem, state::CheckTreeState};
+    use crate::{
+        state::action::{Action, AudioAction, QueueAction},
+        ui::{
+            components::content_view::ActiveView,
+            widgets::tree::{item::CheckTreeItem, state::CheckTreeState},
+        },
+    };
 
+    use super::RADIO_SIZE;
+
+    /// Construct an `Action` to add the checked things to a playlist, if there are any,
+    /// otherwise add the thing being displayed by the view
+    ///
+    /// # Returns
+    ///
+    /// None - if there are no checked things and the current thing is None
+    /// Some(Action) - if there are checked things or the current thing is Some
+    pub fn construct_add_to_playlist_action(
+        checked_things: Vec<Thing>,
+        current_thing: Option<&Thing>,
+    ) -> Option<Action> {
+        if checked_things.is_empty() {
+            current_thing
+                .map(|id| Action::Audio(AudioAction::Queue(QueueAction::Add(vec![id.clone()]))))
+        } else {
+            Some(Action::Audio(AudioAction::Queue(QueueAction::Add(
+                checked_things,
+            ))))
+        }
+    }
+
+    /// Construct an `Action` to add the checked things to the queue if there are any,
+    /// otherwise add the thing being displayed by the view
+    ///
+    /// # Returns
+    ///
+    /// None - if there are no checked things and the current thing is None
+    /// Some(Action) - if there are checked things or the current thing is Some
+    pub fn construct_add_to_queue_action(
+        checked_things: Vec<Thing>,
+        current_thing: Option<&Thing>,
+    ) -> Option<Action> {
+        if checked_things.is_empty() {
+            current_thing
+                .map(|id| Action::Audio(AudioAction::Queue(QueueAction::Add(vec![id.clone()]))))
+        } else {
+            Some(Action::Audio(AudioAction::Queue(QueueAction::Add(
+                checked_things,
+            ))))
+        }
+    }
+
+    /// Construct an `Action` to start a radio from the checked things if there are any,
+    /// otherwise start a radio from the thing being displayed by the view
+    ///
+    /// # Returns
+    ///
+    /// None - if there are no checked things and the current thing is None
+    /// Some(Action) - if there are checked things or the current thing is Some
+    pub fn construct_start_radio_action(
+        checked_things: Vec<Thing>,
+        current_thing: Option<&Thing>,
+    ) -> Option<Action> {
+        if checked_things.is_empty() {
+            current_thing
+                .map(|id| Action::SetCurrentView(ActiveView::Radio(vec![id.clone()], RADIO_SIZE)))
+        } else {
+            Some(Action::SetCurrentView(ActiveView::Radio(
+                checked_things,
+                RADIO_SIZE,
+            )))
+        }
+    }
+
+    /// Get the checked things from the tree state
+    pub fn get_checked_things_from_tree_state(tree_state: &CheckTreeState<String>) -> Vec<Thing> {
+        tree_state
+            .checked()
+            .iter()
+            .filter_map(|id| id.iter().find_map(|id| id.parse::<Thing>().ok()))
+            .collect()
+    }
+
+    /// Get the selected thing from the tree state
     pub fn get_selected_things_from_tree_state(
         tree_state: &CheckTreeState<String>,
     ) -> Option<Thing> {

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -82,12 +82,12 @@ pub mod utils {
     };
     use tui_tree_widget::{TreeItem, TreeState};
 
-    pub fn get_selected_things_from_tree_state(tree_state: &TreeState<String>) -> Vec<Thing> {
+    pub fn get_selected_things_from_tree_state(tree_state: &TreeState<String>) -> Option<Thing> {
         tree_state
             .selected()
             .iter()
             .filter_map(|id| id.parse::<Thing>().ok())
-            .collect()
+            .next()
     }
 
     pub fn create_album_tree_item(albums: &[Album]) -> Result<TreeItem<String>, std::io::Error> {

--- a/tui/src/ui/components/content_view/views/none.rs
+++ b/tui/src/ui/components/content_view/views/none.rs
@@ -39,7 +39,7 @@ impl Component for NoneView {
 }
 
 impl ComponentRender<RenderProps> for NoneView {
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
@@ -50,13 +50,17 @@ impl ComponentRender<RenderProps> for NoneView {
         let area = block.inner(props.area);
         frame.render_widget(block, props.area);
 
+        RenderProps { area, ..props }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
         let text = "No active view";
 
         frame.render_widget(
             Line::from(text)
                 .style(Style::default().fg(TEXT_NORMAL.into()))
                 .alignment(Alignment::Center),
-            area,
+            props.area,
         );
     }
 }

--- a/tui/src/ui/components/content_view/views/playlist.rs
+++ b/tui/src/ui/components/content_view/views/playlist.rs
@@ -133,9 +133,7 @@ impl Component for PlaylistView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();
@@ -179,12 +177,11 @@ impl Component for PlaylistView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::Library(LibraryAction::RemoveSongsFromPlaylist(
                                 props.id.clone(),
-                                things,
+                                vec![thing],
                             )))
                             .unwrap();
                     }
@@ -452,9 +449,7 @@ impl Component for LibraryPlaylistsView {
                         let things =
                             get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                        if !things.is_empty() {
-                            debug_assert!(things.len() == 1);
-                            let thing = things[0].clone();
+                        if let Some(thing) = things {
                             self.action_tx
                                 .send(Action::SetCurrentView(thing.into()))
                                 .unwrap();
@@ -483,9 +478,7 @@ impl Component for LibraryPlaylistsView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::Library(LibraryAction::RemovePlaylist(thing)))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/radio.rs
+++ b/tui/src/ui/components/content_view/views/radio.rs
@@ -105,9 +105,7 @@ impl Component for RadioView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/search.rs
+++ b/tui/src/ui/components/content_view/views/search.rs
@@ -136,9 +136,7 @@ impl Component for SearchView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use mecomp_storage::db::schemas::song::Song;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Modifier, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation},
 };
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     state::action::{Action, AudioAction, PopupAction, QueueAction},
     ui::{
-        colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT},
+        colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT, TEXT_NORMAL},
         components::{content_view::ActiveView, Component, ComponentRender, RenderProps},
         widgets::{
             popups::PopupType,
@@ -26,7 +26,6 @@ use crate::{
 };
 
 use super::{
-    none::NoneView,
     checktree_utils::{
         create_album_tree_leaf, create_artist_tree_item, create_song_tree_leaf,
         get_selected_things_from_tree_state,
@@ -142,31 +141,26 @@ impl Component for SongView {
 }
 
 impl ComponentRender<RenderProps> for SongView {
-    #[allow(clippy::too_many_lines)]
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
             Style::default().fg(BORDER_UNFOCUSED.into())
         };
 
-        if let Some(state) = &self.props {
-            let block = Block::bordered()
+        // draw borders and get area for the content (album and artists of song)
+        let area = if let Some(state) = &self.props {
+            let border = Block::bordered()
                 .title_top("Song View")
-                .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check")
                 .border_style(border_style);
-            let block_area = block.inner(props.area);
-            frame.render_widget(block, props.area);
+            let area = border.inner(props.area);
+            frame.render_widget(border, props.area);
 
-            // create list to hold song album and artists
-            let album_tree = create_album_tree_leaf(&state.album, Some(Span::raw("Album: ")));
-            let artist_tree = create_artist_tree_item(state.artists.as_slice()).unwrap();
-            let items = &[artist_tree, album_tree];
-
-            let [top, bottom] = *Layout::default()
+            // split area to make room for song info
+            let [info_area, content_area] = *Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(3), Constraint::Min(4)])
-                .split(block_area)
+                .split(area)
             else {
                 panic!("Failed to split song view area")
             };
@@ -220,28 +214,52 @@ impl ComponentRender<RenderProps> for SongView {
                         ),
                     ]),
                 ])
-                .block(
-                    Block::new()
-                        .borders(Borders::BOTTOM)
-                        .title_bottom("q: add to queue | r: start radio | p: add to playlist")
-                        .border_style(border_style),
-                )
                 .alignment(Alignment::Center),
-                top,
+                info_area,
             );
 
-            // render the song artists / album
+            // draw an additional border around the content area to display additional instructions
+            let border = Block::new()
+                .borders(Borders::TOP)
+                .title_top("q: add to queue | r: start radio | p: add to playlist")
+                .border_style(border_style);
+            frame.render_widget(&border, content_area);
+            border.inner(content_area)
+        } else {
+            let border = Block::bordered()
+                .title_top("Song View")
+                .border_style(border_style);
+            frame.render_widget(&border, props.area);
+            border.inner(props.area)
+        };
+
+        RenderProps { area, ..props }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+        if let Some(state) = &self.props {
+            // create a tree to hold song album and artists
+            let album_tree = create_album_tree_leaf(&state.album, Some(Span::raw("Album: ")));
+            let artist_tree = create_artist_tree_item(state.artists.as_slice()).unwrap();
+            let items = &[artist_tree, album_tree];
+
+            // render the song artists / album tree
             frame.render_stateful_widget(
-                CheckTree::new(items).unwrap().highlight_style(
-                    Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                bottom,
+                CheckTree::new(items)
+                    .unwrap()
+                    .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold()),
+                props.area,
                 &mut self.tree_state.lock().unwrap(),
             );
         } else {
-            NoneView.render(frame, props);
+            let text = "No active song";
+
+            frame.render_widget(
+                Line::from(text)
+                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .alignment(Alignment::Center),
+                props.area,
+            );
         }
     }
 }
@@ -422,32 +440,41 @@ impl Component for LibrarySongsView {
 }
 
 impl ComponentRender<RenderProps> for LibrarySongsView {
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
             Style::default().fg(BORDER_UNFOCUSED.into())
         };
 
-        let block = Block::bordered()
+        // draw primary border
+        let border = Block::bordered()
             .title_top(Line::from(vec![
                 Span::styled("Library Songs".to_string(), Style::default().bold()),
                 Span::raw(" sorted by: "),
                 Span::styled(self.props.sort_mode.to_string(), Style::default().italic()),
             ]))
-            .title_bottom("Enter: Open | ←/↑/↓/→: Navigate | \u{2423} Check | s/S: change sort")
+            .title_bottom(" \u{23CE} : Open | ←/↑/↓/→: Navigate | \u{2423} Check")
             .border_style(border_style);
-        let block_area = block.inner(props.area);
-        frame.render_widget(block, props.area);
+        let content_area = border.inner(props.area);
+        frame.render_widget(border, props.area);
 
-        let [top, bottom] = *Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(1), Constraint::Min(4)])
-            .split(block_area)
-        else {
-            panic!("Failed to split library songs view area");
-        };
+        // draw an additional border around the content area to display additional instructions
+        let border = Block::new()
+            .borders(Borders::TOP | Borders::BOTTOM)
+            .title_bottom("s/S: change sort")
+            .border_style(border_style);
+        frame.render_widget(&border, content_area);
+        let content_area = border.inner(content_area);
 
+        RenderProps {
+            area: content_area,
+            is_focused: props.is_focused,
+        }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+        // create a tree to hold the songs
         let items = self
             .props
             .songs
@@ -455,23 +482,13 @@ impl ComponentRender<RenderProps> for LibrarySongsView {
             .map(|song| create_song_tree_leaf(song))
             .collect::<Vec<_>>();
 
-        frame.render_widget(
-            Block::new()
-                .borders(Borders::BOTTOM)
-                .border_style(border_style),
-            top,
-        );
-
+        // render the tree
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(
-                    Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
-                        .add_modifier(Modifier::BOLD),
-                )
+                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
-            bottom,
+            props.area,
             &mut self.tree_state.lock().unwrap(),
         );
     }

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -148,90 +148,87 @@ impl ComponentRender<RenderProps> for SongView {
             Style::default().fg(BORDER_UNFOCUSED.into())
         };
 
+        let border = Block::bordered()
+            .title_top("Song View")
+            .border_style(border_style);
+        frame.render_widget(&border, props.area);
         // draw borders and get area for the content (album and artists of song)
-        let area = if let Some(state) = &self.props {
-            let border = Block::bordered()
-                .title_top("Song View")
-                .border_style(border_style);
-            let area = border.inner(props.area);
-            frame.render_widget(border, props.area);
+        let area = self.props.as_ref().map_or_else(
+            || border.inner(props.area),
+            |state| {
+                let area = border.inner(props.area);
 
-            // split area to make room for song info
-            let [info_area, content_area] = *Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(3), Constraint::Min(4)])
-                .split(area)
-            else {
-                panic!("Failed to split song view area")
-            };
+                // split area to make room for song info
+                let [info_area, content_area] = *Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(3), Constraint::Min(4)])
+                    .split(area)
+                else {
+                    panic!("Failed to split song view area")
+                };
 
-            // render the song info
-            frame.render_widget(
-                Paragraph::new(vec![
-                    Line::from(vec![
-                        Span::styled(state.song.title.to_string(), Style::default().bold()),
-                        Span::raw(" "),
-                        Span::styled(
-                            state
-                                .song
-                                .artist
-                                .iter()
-                                .map(ToString::to_string)
-                                .collect::<Vec<String>>()
-                                .join(", "),
-                            Style::default().italic(),
-                        ),
-                    ]),
-                    Line::from(vec![
-                        Span::raw("Track/Disc: "),
-                        Span::styled(
-                            format!(
-                                "{}/{}",
-                                state.song.track.unwrap_or_default(),
-                                state.song.disc.unwrap_or_default()
+                // render the song info
+                frame.render_widget(
+                    Paragraph::new(vec![
+                        Line::from(vec![
+                            Span::styled(state.song.title.to_string(), Style::default().bold()),
+                            Span::raw(" "),
+                            Span::styled(
+                                state
+                                    .song
+                                    .artist
+                                    .iter()
+                                    .map(ToString::to_string)
+                                    .collect::<Vec<String>>()
+                                    .join(", "),
+                                Style::default().italic(),
                             ),
-                            Style::default().italic(),
-                        ),
-                        Span::raw("  Duration: "),
-                        Span::styled(
-                            format!(
-                                "{}:{:04.1}",
-                                state.song.runtime.as_secs() / 60,
-                                state.song.runtime.as_secs_f32() % 60.0,
+                        ]),
+                        Line::from(vec![
+                            Span::raw("Track/Disc: "),
+                            Span::styled(
+                                format!(
+                                    "{}/{}",
+                                    state.song.track.unwrap_or_default(),
+                                    state.song.disc.unwrap_or_default()
+                                ),
+                                Style::default().italic(),
                             ),
-                            Style::default().italic(),
-                        ),
-                        Span::raw("  Genre(s): "),
-                        Span::styled(
-                            state
-                                .song
-                                .genre
-                                .iter()
-                                .map(ToString::to_string)
-                                .collect::<Vec<String>>()
-                                .join(", "),
-                            Style::default().italic(),
-                        ),
-                    ]),
-                ])
-                .alignment(Alignment::Center),
-                info_area,
-            );
+                            Span::raw("  Duration: "),
+                            Span::styled(
+                                format!(
+                                    "{}:{:04.1}",
+                                    state.song.runtime.as_secs() / 60,
+                                    state.song.runtime.as_secs_f32() % 60.0,
+                                ),
+                                Style::default().italic(),
+                            ),
+                            Span::raw("  Genre(s): "),
+                            Span::styled(
+                                state
+                                    .song
+                                    .genre
+                                    .iter()
+                                    .map(ToString::to_string)
+                                    .collect::<Vec<String>>()
+                                    .join(", "),
+                                Style::default().italic(),
+                            ),
+                        ]),
+                    ])
+                    .alignment(Alignment::Center),
+                    info_area,
+                );
 
-            // draw an additional border around the content area to display additional instructions
-            let border = Block::new()
-                .borders(Borders::TOP)
-                .title_top("q: add to queue | r: start radio | p: add to playlist")
-                .border_style(border_style);
-            frame.render_widget(&border, content_area);
-            border.inner(content_area)
-        } else {
-            let border = Block::bordered()
-                .title_top("Song View")
-                .border_style(border_style);
-            frame.render_widget(&border, props.area);
-            border.inner(props.area)
-        };
+                // draw an additional border around the content area to display additional instructions
+                let border = Block::new()
+                    .borders(Borders::TOP)
+                    .title_top("q: add to queue | r: start radio | p: add to playlist")
+                    .border_style(border_style);
+                frame.render_widget(&border, content_area);
+                border.inner(content_area)
+            },
+        );
 
         RenderProps { area, ..props }
     }

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -93,9 +93,7 @@ impl Component for SongView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();
@@ -399,9 +397,7 @@ impl Component for LibrarySongsView {
                     let things =
                         get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                    if !things.is_empty() {
-                        debug_assert!(things.len() == 1);
-                        let thing = things[0].clone();
+                    if let Some(thing) = things {
                         self.action_tx
                             .send(Action::SetCurrentView(thing.into()))
                             .unwrap();

--- a/tui/src/ui/components/control_panel.rs
+++ b/tui/src/ui/components/control_panel.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     state::action::{Action, AudioAction, PlaybackAction, VolumeAction},
     ui::colors::{
-        BORDER_FOCUSED, BORDER_UNFOCUSED, GAUGE_BACKGROUND, GAUGE_FOREGROUND, TEXT_HIGHLIGHT_ALT,
+        BORDER_FOCUSED, BORDER_UNFOCUSED, GAUGE_FILLED, GAUGE_UNFILLED, TEXT_HIGHLIGHT_ALT,
         TEXT_NORMAL,
     },
 };
@@ -257,12 +257,8 @@ impl ComponentRender<RenderProps> for ControlPanel {
                     ),
                     Style::default().fg(TEXT_NORMAL.into()),
                 ))
-                .gauge_style(
-                    Style::default()
-                        .fg(GAUGE_FOREGROUND.into())
-                        .bg(GAUGE_BACKGROUND.into())
-                        .bold(),
-                )
+                .filled_style(Style::default().fg(GAUGE_FILLED.into()).bold())
+                .unfilled_style(Style::default().fg(GAUGE_UNFILLED.into()).bold())
                 .ratio(self.props.song_runtime.map_or(0.0, |runtime| {
                     runtime.seek_position.as_secs_f64() / runtime.duration.as_secs_f64()
                 })),

--- a/tui/src/ui/components/control_panel.rs
+++ b/tui/src/ui/components/control_panel.rs
@@ -281,7 +281,7 @@ impl ComponentRender<RenderProps> for ControlPanel {
         // bottom (instructions)
         frame.render_widget(
             Line::from(
-                "n/p: next/previous | space: play/pause | m: mute | +/-: volume | ←/→: seek",
+                "n/p: next/previous | \u{2423}: play/pause | m: mute | +/-: volume | ←/→: seek",
             )
             .style(Style::default().italic().fg(TEXT_NORMAL.into()))
             .alignment(Alignment::Center),

--- a/tui/src/ui/components/control_panel.rs
+++ b/tui/src/ui/components/control_panel.rs
@@ -152,8 +152,7 @@ impl Component for ControlPanel {
 }
 
 impl ComponentRender<RenderProps> for ControlPanel {
-    #[allow(clippy::too_many_lines)]
-    fn render(&self, frame: &mut ratatui::Frame, props: RenderProps) {
+    fn render_border(&self, frame: &mut ratatui::Frame, props: RenderProps) -> RenderProps {
         let border_style = if props.is_focused {
             Style::default().fg(BORDER_FOCUSED.into())
         } else {
@@ -166,6 +165,13 @@ impl ComponentRender<RenderProps> for ControlPanel {
         let block_area = block.inner(props.area);
         frame.render_widget(block, props.area);
 
+        RenderProps {
+            area: block_area,
+            ..props
+        }
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, props: RenderProps) {
         let [top, middle, bottom] = *Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -173,7 +179,7 @@ impl ComponentRender<RenderProps> for ControlPanel {
                 Constraint::Fill(1),
                 Constraint::Fill(1),
             ])
-            .split(block_area)
+            .split(props.area)
         else {
             panic!("main layout must have 3 children");
         };

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -30,5 +30,15 @@ pub trait Component {
 }
 
 pub trait ComponentRender<Props> {
-    fn render(&self, frame: &mut Frame, props: Props);
+    /// Render the border of the view, and return the props updated with the remaining area for the view.
+    fn render_border(&self, frame: &mut Frame, props: Props) -> Props;
+
+    /// Render the view's content.
+    fn render_content(&self, frame: &mut Frame, props: Props);
+
+    /// Render the view (border and content).
+    fn render(&self, frame: &mut Frame, props: Props) {
+        let props = self.render_border(frame, props);
+        self.render_content(frame, props);
+    }
 }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -155,7 +155,7 @@ impl UiManager {
             }
 
             if let Err(err) = terminal
-                .draw(|frame| app.render(frame, ()))
+                .draw(|frame| app.render(frame, frame.size()))
                 .context("could not render to the terminal")
             {
                 break Err(err);

--- a/tui/src/ui/widgets/input_box.rs
+++ b/tui/src/ui/widgets/input_box.rs
@@ -129,6 +129,7 @@ impl Component for InputBox {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct RenderProps<'a> {
     pub border: Block<'a>,
     pub area: Rect,
@@ -137,10 +138,17 @@ pub struct RenderProps<'a> {
 }
 
 impl<'a> ComponentRender<RenderProps<'a>> for InputBox {
-    fn render(&self, frame: &mut Frame, props: RenderProps) {
-        let input = Paragraph::new(self.text.as_str())
-            .style(Style::default().fg(props.text_color))
-            .block(props.border);
+    fn render_border(&self, frame: &mut Frame, props: RenderProps<'a>) -> RenderProps<'a> {
+        let view_area = props.border.inner(props.area);
+        frame.render_widget(&props.border, props.area);
+        RenderProps {
+            area: view_area,
+            ..props
+        }
+    }
+
+    fn render_content(&self, frame: &mut Frame, props: RenderProps<'a>) {
+        let input = Paragraph::new(self.text.as_str()).style(Style::default().fg(props.text_color));
         frame.render_widget(input, props.area);
 
         // Cursor is hidden by default, so we need to make it visible if the input box is selected
@@ -151,9 +159,8 @@ impl<'a> ComponentRender<RenderProps<'a>> for InputBox {
             frame.set_cursor(
                 // Draw the cursor at the current position in the input field.
                 // This position is can be controlled via the left and right arrow key
-                props.area.x + self.cursor_position as u16 + 1,
-                // Move one line down, from the border to the input line
-                props.area.y + 1,
+                props.area.x + self.cursor_position as u16,
+                props.area.y,
             );
         }
     }

--- a/tui/src/ui/widgets/mod.rs
+++ b/tui/src/ui/widgets/mod.rs
@@ -1,2 +1,3 @@
 pub mod input_box;
 pub mod popups;
+pub mod tree;

--- a/tui/src/ui/widgets/popups/mod.rs
+++ b/tui/src/ui/widgets/popups/mod.rs
@@ -51,17 +51,9 @@ pub trait Popup: for<'a> ComponentRender<Rect> + Send + Sync {
         }
     }
 
-    /// Use this method to handle rendering the popup.
-    ///
-    /// It draws a border with the given title and instructions and
-    /// renders the component implementing popup.
-    fn render_popup(&self, frame: &mut ratatui::Frame) {
+    fn render_popup_border(&self, frame: &mut ratatui::Frame, area: Rect) -> Rect {
         let title = self.title();
         let instructions = self.instructions();
-        let area = self.area(frame.size());
-
-        // clear the popup area
-        frame.render_widget(Clear, area);
 
         // Draw border with title and instructions
         let border = Block::bordered()
@@ -70,8 +62,20 @@ pub trait Popup: for<'a> ComponentRender<Rect> + Send + Sync {
             .border_style(Style::default().fg(self.border_color()));
         let component_area = border.inner(area);
         frame.render_widget(border, area);
+        component_area
+    }
 
-        self.render(frame, component_area);
+    /// Use this method to handle rendering the popup.
+    ///
+    /// It draws a border with the given title and instructions and
+    /// renders the component implementing popup.
+    fn render_popup(&self, frame: &mut ratatui::Frame) {
+        let area = self.area(frame.size());
+
+        // clear the popup area
+        frame.render_widget(Clear, area);
+
+        self.render(frame, area);
     }
 }
 

--- a/tui/src/ui/widgets/popups/mod.rs
+++ b/tui/src/ui/widgets/popups/mod.rs
@@ -28,6 +28,7 @@ pub trait Popup: for<'a> ComponentRender<Rect> + Send + Sync {
     }
 
     // TODO: implement a way for popups to listen to application state changes
+    fn update_with_state(&mut self, state: &AppState);
 
     /// Key Event Handler for the inner component of the popup,
     /// this method is called when the key event is not the escape key.

--- a/tui/src/ui/widgets/popups/notification.rs
+++ b/tui/src/ui/widgets/popups/notification.rs
@@ -8,7 +8,11 @@ use super::Popup;
 pub struct Notification<'a>(pub Line<'a>);
 
 impl<'a> ComponentRender<Rect> for Notification<'a> {
-    fn render(&self, frame: &mut ratatui::Frame, area: Rect) {
+    fn render_border(&self, frame: &mut ratatui::Frame, area: Rect) -> Rect {
+        self.render_popup_border(frame, area)
+    }
+
+    fn render_content(&self, frame: &mut ratatui::Frame, area: Rect) {
         frame.render_widget::<Line>(self.0.clone(), area);
     }
 }

--- a/tui/src/ui/widgets/popups/notification.rs
+++ b/tui/src/ui/widgets/popups/notification.rs
@@ -22,6 +22,8 @@ impl<'a> Popup for Notification<'a> {
         Line::from("Press ESC to close")
     }
 
+    fn update_with_state(&mut self, _: &crate::ui::AppState) {}
+
     fn area(&self, terminal_area: Rect) -> Rect {
         // put in the top left corner, give enough width to display the text (cap at 50% of the terminal width)
         let max_width = terminal_area.width / 2;

--- a/tui/src/ui/widgets/popups/playlist.rs
+++ b/tui/src/ui/widgets/popups/playlist.rs
@@ -176,9 +176,7 @@ impl Popup for PlaylistSelector {
                         let things =
                             get_selected_things_from_tree_state(&self.tree_state.lock().unwrap());
 
-                        if !things.is_empty() {
-                            debug_assert!(things.len() == 1);
-                            let thing = things[0].clone();
+                        if let Some(thing) = things {
                             // add the items to the selected playlist
                             self.action_tx
                                 .send(Action::Library(LibraryAction::AddThingsToPlaylist(

--- a/tui/src/ui/widgets/popups/playlist.rs
+++ b/tui/src/ui/widgets/popups/playlist.rs
@@ -80,6 +80,10 @@ impl Popup for PlaylistSelector {
         })
     }
 
+    fn update_with_state(&mut self, state: &AppState) {
+        self.props = Props::from(state);
+    }
+
     fn area(&self, terminal_area: Rect) -> Rect {
         let [_, horizontal_area, _] = *Layout::default()
             .direction(Direction::Horizontal)

--- a/tui/src/ui/widgets/tree/flatten.rs
+++ b/tui/src/ui/widgets/tree/flatten.rs
@@ -1,12 +1,12 @@
 /**
-This is a snippet from the tui_tree_widget crate, with modifications. The original source can be found at:
-https://github.com/EdJoPaTo/tui-rs-tree-widget/blob/b5fc5ca6938421bc83cf2e22e5c32846ac0a6413/src/flatten.rs
+This is a snippet from the `tui_tree_widget` crate, with modifications. The original source can be found at:
+<https://github.com/EdJoPaTo/tui-rs-tree-widget/blob/b5fc5ca6938421bc83cf2e22e5c32846ac0a6413/src/flatten.rs>
 
 the original source code is under the following license:
 
 MIT License
 
-Copyright (c) EdJoPaTo
+Copyright (c) `EdJoPaTo`
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tui/src/ui/widgets/tree/flatten.rs
+++ b/tui/src/ui/widgets/tree/flatten.rs
@@ -1,0 +1,138 @@
+/**
+This is a snippet from the tui_tree_widget crate, with modifications. The original source can be found at:
+https://github.com/EdJoPaTo/tui-rs-tree-widget/blob/b5fc5ca6938421bc83cf2e22e5c32846ac0a6413/src/flatten.rs
+
+the original source code is under the following license:
+
+MIT License
+
+Copyright (c) EdJoPaTo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+use std::collections::HashSet;
+
+use super::item::CheckTreeItem;
+
+/// A flattened item of all visible [`CheckTreeItem`]s.
+///
+/// Generated via [`CheckTreeState::flatten`](super::CheckTreeState::flatten).
+#[must_use]
+pub struct Flattened<'text, Identifier> {
+    pub identifier: Vec<Identifier>,
+    pub item: &'text CheckTreeItem<'text, Identifier>,
+}
+
+impl<Identifier> Flattened<'_, Identifier> {
+    /// Zero based depth. Depth 0 means top level with 0 indentation.
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.identifier.len() - 1
+    }
+}
+
+/// Get a flat list of all visible [`CheckTreeItem`]s.
+///
+/// `current` starts empty: `&[]`
+#[must_use]
+pub fn flatten<'text, Identifier>(
+    open_identifiers: &HashSet<Vec<Identifier>>,
+    items: &'text [CheckTreeItem<'text, Identifier>],
+    current: &[Identifier],
+) -> Vec<Flattened<'text, Identifier>>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    let mut result = Vec::new();
+    for item in items {
+        let mut child_identifier = current.to_vec();
+        child_identifier.push(item.identifier.clone());
+
+        let child_result = open_identifiers
+            .contains(&child_identifier)
+            .then(|| flatten(open_identifiers, &item.children, &child_identifier));
+
+        result.push(Flattened {
+            identifier: child_identifier,
+            item,
+        });
+
+        if let Some(mut child_result) = child_result {
+            result.append(&mut child_result);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depth_works() {
+        let mut open = HashSet::new();
+        open.insert(vec!["b"]);
+        open.insert(vec!["b", "d"]);
+        let depths = flatten(&open, &CheckTreeItem::example(), &[])
+            .into_iter()
+            .map(|flattened| flattened.depth())
+            .collect::<Vec<_>>();
+        assert_eq!(depths, [0, 0, 1, 1, 2, 2, 1, 0]);
+    }
+
+    #[cfg(test)]
+    fn flatten_works(open: &HashSet<Vec<&'static str>>, expected: &[&str]) {
+        let items = CheckTreeItem::example();
+        let result = flatten(open, &items, &[]);
+        let actual = result
+            .into_iter()
+            .map(|flattened| flattened.identifier.into_iter().last().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn flatten_nothing_open_is_top_level() {
+        let open = HashSet::new();
+        flatten_works(&open, &["a", "b", "h"]);
+    }
+
+    #[test]
+    fn flatten_wrong_open_is_only_top_level() {
+        let mut open = HashSet::new();
+        open.insert(vec!["a"]);
+        open.insert(vec!["b", "d"]);
+        flatten_works(&open, &["a", "b", "h"]);
+    }
+
+    #[test]
+    fn flatten_one_is_open() {
+        let mut open = HashSet::new();
+        open.insert(vec!["b"]);
+        flatten_works(&open, &["a", "b", "c", "d", "g", "h"]);
+    }
+
+    #[test]
+    fn flatten_all_open() {
+        let mut open = HashSet::new();
+        open.insert(vec!["b"]);
+        open.insert(vec!["b", "d"]);
+        flatten_works(&open, &["a", "b", "c", "d", "e", "f", "g", "h"]);
+    }
+}

--- a/tui/src/ui/widgets/tree/item.rs
+++ b/tui/src/ui/widgets/tree/item.rs
@@ -1,0 +1,173 @@
+use std::collections::HashSet;
+
+use ratatui::text::Text;
+
+/// One item inside a [`CheckTree`](super::CheckTree).
+///
+/// Can have zero or more `children`.
+///
+/// # Identifier
+///
+/// The generic argument `Identifier` is used to keep the state like the currently selected or opened [`CheckTreeItem`]s in the [`CheckTreeState`](super::state::CheckTreeState).
+///
+/// It needs to be unique among its siblings but can be used again on parent or child [`CheckTreeItem`]s.
+/// A common example would be a filename which has to be unique in its directory while it can exist in another.
+///
+/// The `text` can be different from its `identifier`.
+/// To repeat the filename analogy: File browsers sometimes hide file extensions.
+/// The filename `main.rs` is the identifier while its shown as `main`.
+/// Two files `main.rs` and `main.toml` can exist in the same directory and can both be displayed as `main` but their identifier is different.
+///
+/// Just like every file in a file system can be uniquely identified with its file and directory names each [`CheckTreeItem`] in a [`CheckTree`](super::CheckTree) can be with these identifiers.
+/// As an example the following two identifiers describe the main file in a Rust cargo project: `vec!["src", "main.rs"]`.
+#[derive(Debug, Clone)]
+pub struct CheckTreeItem<'text, Identifier> {
+    pub(super) identifier: Identifier,
+    pub(super) text: Text<'text>,
+    pub(super) children: Vec<Self>,
+}
+
+impl<'text, Identifier> CheckTreeItem<'text, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    /// Create a new `TreeItem` without children.
+    #[must_use]
+    pub fn new_leaf<T>(identifier: Identifier, text: T) -> Self
+    where
+        T: Into<Text<'text>>,
+    {
+        Self {
+            identifier,
+            text: text.into(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Create a new `TreeItem` with children.
+    ///
+    /// # Errors
+    ///
+    /// Errors when there are duplicate identifiers in the children.
+    pub fn new<T>(identifier: Identifier, text: T, children: Vec<Self>) -> std::io::Result<Self>
+    where
+        T: Into<Text<'text>>,
+    {
+        let identifiers = children
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<HashSet<_>>();
+        if identifiers.len() != children.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "The children contain duplicate identifiers",
+            ));
+        }
+
+        Ok(Self {
+            identifier,
+            text: text.into(),
+            children,
+        })
+    }
+
+    /// Get a reference to the identifier.
+    #[must_use]
+    pub const fn identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
+    #[must_use]
+    pub fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    /// Get a reference to a child by index.
+    #[must_use]
+    pub fn child(&self, index: usize) -> Option<&Self> {
+        self.children.get(index)
+    }
+
+    /// Get a mutable reference to a child by index.
+    ///
+    /// When you choose to change the `identifier` the [`TreeState`](crate::TreeState) might not work as expected afterwards.
+    #[must_use]
+    pub fn child_mut(&mut self, index: usize) -> Option<&mut Self> {
+        self.children.get_mut(index)
+    }
+
+    #[must_use]
+    pub fn height(&self) -> usize {
+        self.text.height()
+    }
+
+    /// Add a child to the `TreeItem`.
+    ///
+    /// # Errors
+    ///
+    /// Errors when the `identifier` of the `child` already exists in the children.
+    pub fn add_child(&mut self, child: Self) -> std::io::Result<()> {
+        let existing = self
+            .children
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<HashSet<_>>();
+        if existing.contains(&child.identifier) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "identifier already exists in the children",
+            ));
+        }
+
+        self.children.push(child);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl CheckTreeItem<'static, &'static str> {
+    #[must_use]
+    pub(crate) fn example() -> Vec<Self> {
+        vec![
+            Self::new_leaf("a", "Alfa"),
+            Self::new(
+                "b",
+                "Bravo",
+                vec![
+                    Self::new_leaf("c", "Charlie"),
+                    Self::new(
+                        "d",
+                        "Delta",
+                        vec![Self::new_leaf("e", "Echo"), Self::new_leaf("f", "Foxtrot")],
+                    )
+                    .expect("all item identifiers are unique"),
+                    Self::new_leaf("g", "Golf"),
+                ],
+            )
+            .expect("all item identifiers are unique"),
+            Self::new_leaf("h", "Hotel"),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic = "duplicate identifiers"]
+    fn tree_item_new_errors_with_duplicate_identifiers() {
+        let item = CheckTreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        CheckTreeItem::new("root", "Root", vec![item, another]).unwrap();
+    }
+
+    #[test]
+    #[should_panic = "identifier already exists"]
+    fn tree_item_add_child_errors_with_duplicate_identifiers() {
+        let item = CheckTreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        let mut root = CheckTreeItem::new("root", "Root", vec![item]).unwrap();
+        root.add_child(another).unwrap();
+    }
+}

--- a/tui/src/ui/widgets/tree/item.rs
+++ b/tui/src/ui/widgets/tree/item.rs
@@ -21,17 +21,19 @@ use ratatui::text::Text;
 /// Just like every file in a file system can be uniquely identified with its file and directory names each [`CheckTreeItem`] in a [`CheckTree`](super::CheckTree) can be with these identifiers.
 /// As an example the following two identifiers describe the main file in a Rust cargo project: `vec!["src", "main.rs"]`.
 #[derive(Debug, Clone)]
+#[allow(clippy::module_name_repetitions)]
 pub struct CheckTreeItem<'text, Identifier> {
     pub(super) identifier: Identifier,
     pub(super) text: Text<'text>,
     pub(super) children: Vec<Self>,
 }
 
+#[allow(dead_code)]
 impl<'text, Identifier> CheckTreeItem<'text, Identifier>
 where
     Identifier: Clone + PartialEq + Eq + core::hash::Hash,
 {
-    /// Create a new `TreeItem` without children.
+    /// Create a new `CheckTreeItem` without children.
     #[must_use]
     pub fn new_leaf<T>(identifier: Identifier, text: T) -> Self
     where
@@ -44,7 +46,7 @@ where
         }
     }
 
-    /// Create a new `TreeItem` with children.
+    /// Create a new `CheckTreeItem` with children.
     ///
     /// # Errors
     ///
@@ -90,7 +92,7 @@ where
 
     /// Get a mutable reference to a child by index.
     ///
-    /// When you choose to change the `identifier` the [`TreeState`](crate::TreeState) might not work as expected afterwards.
+    /// When you choose to change the `identifier` the [`CheckTreeState`](super::CheckTreeState) might not work as expected afterwards.
     #[must_use]
     pub fn child_mut(&mut self, index: usize) -> Option<&mut Self> {
         self.children.get_mut(index)
@@ -101,7 +103,7 @@ where
         self.text.height()
     }
 
-    /// Add a child to the `TreeItem`.
+    /// Add a child to the `CheckTreeItem`.
     ///
     /// # Errors
     ///

--- a/tui/src/ui/widgets/tree/mod.rs
+++ b/tui/src/ui/widgets/tree/mod.rs
@@ -18,9 +18,10 @@ use unicode_width::UnicodeWidthStr;
 /// The generic argument `Identifier` is used to keep the state like the currently selected or opened [`CheckTreeItem`]s in the [`CheckTreeState`].
 /// For more information see [`CheckTreeItem`].
 ///
-/// This differs from the tui_tree_widget crate's `Tree` in that it allows for checkboxes to be rendered next to each leaf item.
+/// This differs from the `tui_tree_widget` crate's `Tree` in that it allows for checkboxes to be rendered next to each leaf item.
 /// This is useful for creating a tree of items that can be selected.
 #[derive(Debug, Clone)]
+#[allow(clippy::module_name_repetitions)]
 pub struct CheckTree<'a, Identifier> {
     items: &'a [CheckTreeItem<'a, Identifier>],
 
@@ -46,6 +47,7 @@ pub struct CheckTree<'a, Identifier> {
     _identifier: std::marker::PhantomData<Identifier>,
 }
 
+#[allow(dead_code)]
 impl<'a, Identifier> CheckTree<'a, Identifier>
 where
     Identifier: Clone + PartialEq + Eq + core::hash::Hash,
@@ -165,7 +167,7 @@ impl<'a, Identifier: 'a + Clone + PartialEq + Eq + core::hash::Hash> StatefulWid
             return;
         }
 
-        let visible = state.flatten(&self.items);
+        let visible = state.flatten(self.items);
         state.last_biggest_index = visible.len().saturating_sub(1);
         if visible.is_empty() {
             return;

--- a/tui/src/ui/widgets/tree/mod.rs
+++ b/tui/src/ui/widgets/tree/mod.rs
@@ -1,0 +1,452 @@
+pub mod flatten;
+pub mod item;
+pub mod state;
+
+use flatten::Flattened;
+use item::CheckTreeItem;
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    widgets::{Block, Scrollbar, ScrollbarState, StatefulWidget, Widget},
+};
+use state::CheckTreeState;
+use unicode_width::UnicodeWidthStr;
+
+/// A `CheckTree` which can be rendered.
+///
+/// The generic argument `Identifier` is used to keep the state like the currently selected or opened [`CheckTreeItem`]s in the [`CheckTreeState`].
+/// For more information see [`CheckTreeItem`].
+///
+/// This differs from the tui_tree_widget crate's `Tree` in that it allows for checkboxes to be rendered next to each leaf item.
+/// This is useful for creating a tree of items that can be selected.
+#[derive(Debug, Clone)]
+pub struct CheckTree<'a, Identifier> {
+    items: &'a [CheckTreeItem<'a, Identifier>],
+
+    block: Option<Block<'a>>,
+    scrollbar: Option<Scrollbar<'a>>,
+    /// Style used as a base style for the widget
+    style: Style,
+
+    /// Style used to render selected item
+    highlight_style: Style,
+    /// Symbol in front of the selected item (Shift all items to the right)
+    highlight_symbol: &'a str,
+
+    /// Symbol displayed in front of a closed node (As in the children are currently not visible)
+    node_closed_symbol: &'a str,
+    /// Symbol displayed in front of an open node. (As in the children are currently visible)
+    node_open_symbol: &'a str,
+    /// Symbol displayed in front of a node without children, that is checked
+    node_checked_symbol: &'a str,
+    /// Symbol displayed in front of a node without children, that is not checked
+    node_unchecked_symbol: &'a str,
+
+    _identifier: std::marker::PhantomData<Identifier>,
+}
+
+impl<'a, Identifier> CheckTree<'a, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    /// Create a new `CheckTree`.
+    ///
+    /// # Errors
+    ///
+    /// Errors when there are duplicate identifiers in the children.
+    pub fn new(items: &'a [CheckTreeItem<'a, Identifier>]) -> Result<Self, std::io::Error> {
+        let identifiers = items
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<std::collections::HashSet<_>>();
+        if identifiers.len() != items.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "duplicate identifiers",
+            ));
+        }
+
+        Ok(Self {
+            items,
+            block: None,
+            scrollbar: None,
+            style: Style::new(),
+            highlight_style: Style::new(),
+            highlight_symbol: "",
+            node_closed_symbol: "\u{25b6} ", // ▸ Arrow to right (alt. ▸ U+25B8 BLACK RIGHT-POINTING SMALL TRIANGLE)
+            node_open_symbol: "\u{25bc} ", // ▼ Arrow down (alt. ▾ U+25BE BLACK DOWN-POINTING SMALL TRIANGLE)
+            node_checked_symbol: "\u{2611} ", // ☑ U+2611 BALLOT BOX WITH CHECK
+            node_unchecked_symbol: "\u{2610} ", // ☐ U+2610 BALLOT BOX
+            _identifier: std::marker::PhantomData,
+        })
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    #[must_use]
+    pub fn block(mut self, block: Block<'a>) -> Self {
+        self.block = Some(block);
+        self
+    }
+
+    /// Show the scrollbar when rendering this widget.
+    ///
+    /// Experimental: Can change on any release without any additional notice.
+    /// Its there to test and experiment with whats possible with scrolling widgets.
+    /// Also see <https://github.com/ratatui-org/ratatui/issues/174>
+    #[must_use]
+    pub const fn experimental_scrollbar(mut self, scrollbar: Option<Scrollbar<'a>>) -> Self {
+        self.scrollbar = scrollbar;
+        self
+    }
+
+    #[must_use]
+    pub const fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    #[must_use]
+    pub const fn highlight_style(mut self, style: Style) -> Self {
+        self.highlight_style = style;
+        self
+    }
+
+    #[must_use]
+    pub const fn highlight_symbol(mut self, highlight_symbol: &'a str) -> Self {
+        self.highlight_symbol = highlight_symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_closed_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_closed_symbol = symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_open_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_open_symbol = symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_selected_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_checked_symbol = symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_unselected_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_unchecked_symbol = symbol;
+        self
+    }
+}
+
+impl<'a, Identifier: 'a + Clone + PartialEq + Eq + core::hash::Hash> StatefulWidget
+    for CheckTree<'a, Identifier>
+{
+    type State = CheckTreeState<Identifier>;
+
+    #[allow(clippy::too_many_lines)]
+    fn render(self, full_area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        buf.set_style(full_area, self.style);
+
+        // Get the inner area inside a possible block, otherwise use the full area
+        let area = self.block.map_or(full_area, |block| {
+            let inner_area = block.inner(full_area);
+            block.render(full_area, buf);
+            inner_area
+        });
+
+        state.last_area = area;
+        state.last_rendered_identifiers.clear();
+        if area.width < 1 || area.height < 1 {
+            return;
+        }
+
+        let visible = state.flatten(&self.items);
+        state.last_biggest_index = visible.len().saturating_sub(1);
+        if visible.is_empty() {
+            return;
+        }
+        let available_height = area.height as usize;
+
+        let ensure_index_in_view =
+            if state.ensure_selected_in_view_on_next_render && !state.selected.is_empty() {
+                visible
+                    .iter()
+                    .position(|flattened| flattened.identifier == state.selected)
+            } else {
+                None
+            };
+
+        // Ensure last line is still visible
+        let mut start = state.offset.min(state.last_biggest_index);
+
+        if let Some(ensure_index_in_view) = ensure_index_in_view {
+            start = start.min(ensure_index_in_view);
+        }
+
+        let mut end = start;
+        let mut height = 0;
+        for item_height in visible
+            .iter()
+            .skip(start)
+            .map(|flattened| flattened.item.height())
+        {
+            if height + item_height > available_height {
+                break;
+            }
+            height += item_height;
+            end += 1;
+        }
+
+        if let Some(ensure_index_in_view) = ensure_index_in_view {
+            while ensure_index_in_view >= end {
+                height += visible[end].item.height();
+                end += 1;
+                while height > available_height {
+                    height = height.saturating_sub(visible[start].item.height());
+                    start += 1;
+                }
+            }
+        }
+
+        state.offset = start;
+        state.ensure_selected_in_view_on_next_render = false;
+
+        if let Some(scrollbar) = self.scrollbar {
+            let mut scrollbar_state = ScrollbarState::new(visible.len().saturating_sub(height))
+                .position(start)
+                .viewport_content_length(height);
+            let scrollbar_area = Rect {
+                // Inner height to be exactly as the content
+                y: area.y,
+                height: area.height,
+                // Outer width to stay on the right border
+                x: full_area.x,
+                width: full_area.width,
+            };
+            scrollbar.render(scrollbar_area, buf, &mut scrollbar_state);
+        }
+
+        let blank_symbol = " ".repeat(self.highlight_symbol.width());
+
+        let mut current_height = 0;
+        let has_selection = !state.selected.is_empty();
+        #[allow(clippy::cast_possible_truncation)]
+        for flattened in visible.iter().skip(state.offset).take(end - start) {
+            let Flattened { identifier, item } = flattened;
+
+            let x = area.x;
+            let y = area.y + current_height;
+            let height = item.height() as u16;
+            current_height += height;
+
+            let area = Rect {
+                x,
+                y,
+                width: area.width,
+                height,
+            };
+
+            let text = &item.text;
+            let item_style = text.style;
+
+            let is_selected = state.selected == *identifier;
+            let after_highlight_symbol_x = if has_selection {
+                let symbol = if is_selected {
+                    self.highlight_symbol
+                } else {
+                    &blank_symbol
+                };
+                let (x, _) = buf.set_stringn(x, y, symbol, area.width as usize, item_style);
+                x
+            } else {
+                x
+            };
+
+            let after_depth_x = {
+                let indent_width = flattened.depth() * 2;
+                let (after_indent_x, _) = buf.set_stringn(
+                    after_highlight_symbol_x,
+                    y,
+                    " ".repeat(indent_width),
+                    indent_width,
+                    item_style,
+                );
+                let symbol = if text.width() == 0 {
+                    "  "
+                } else if item.children.is_empty() {
+                    if state.checked.contains(identifier) {
+                        self.node_checked_symbol
+                    } else {
+                        self.node_unchecked_symbol
+                    }
+                } else if state.opened.contains(identifier) {
+                    self.node_open_symbol
+                } else {
+                    self.node_closed_symbol
+                };
+                let max_width = area.width.saturating_sub(after_indent_x - x);
+                let (x, _) =
+                    buf.set_stringn(after_indent_x, y, symbol, max_width as usize, item_style);
+                x
+            };
+
+            let text_area = Rect {
+                x: after_depth_x,
+                width: area.width.saturating_sub(after_depth_x - x),
+                ..area
+            };
+            text.render(text_area, buf);
+
+            if is_selected {
+                buf.set_style(area, self.highlight_style);
+            }
+
+            state
+                .last_rendered_identifiers
+                .push((area.y, identifier.clone()));
+        }
+        state.last_identifiers = visible
+            .into_iter()
+            .map(|flattened| flattened.identifier)
+            .collect();
+    }
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[must_use]
+    #[track_caller]
+    fn render(width: u16, height: u16, state: &mut CheckTreeState<&'static str>) -> Buffer {
+        let items = CheckTreeItem::example();
+        let tree = CheckTree::new(&items).unwrap();
+        let area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(area);
+        StatefulWidget::render(tree, area, &mut buffer, state);
+        buffer
+    }
+
+    #[test]
+    #[should_panic = "duplicate identifiers"]
+    fn tree_new_errors_with_duplicate_identifiers() {
+        let item = CheckTreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        let items = [item, another];
+        let _: CheckTree<_> = CheckTree::new(&items).unwrap();
+    }
+
+    #[test]
+    fn does_not_panic() {
+        _ = render(0, 0, &mut CheckTreeState::default());
+        _ = render(10, 0, &mut CheckTreeState::default());
+        _ = render(0, 10, &mut CheckTreeState::default());
+        _ = render(10, 10, &mut CheckTreeState::default());
+    }
+
+    #[test]
+    fn nothing_open() {
+        let buffer = render(10, 4, &mut CheckTreeState::default());
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "☐ Alfa    ",
+            "▶ Bravo   ",
+            "☐ Hotel   ",
+            "          ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn check_leaf_d1() {
+        let mut state = CheckTreeState::default();
+        state.check(vec!["a"]);
+        let buffer = render(10, 4, &mut state);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "☑ Alfa    ",
+            "▶ Bravo   ",
+            "☐ Hotel   ",
+            "          ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn check_parent_d1() {
+        let mut state = CheckTreeState::default();
+        state.check(vec!["b"]);
+        let buffer = render(10, 4, &mut state);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "☐ Alfa    ",
+            "▶ Bravo   ",
+            "☐ Hotel   ",
+            "          ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn check_leaf_d2() {
+        let mut state = CheckTreeState::default();
+        state.open(vec!["b"]);
+        state.check(vec!["b", "c"]);
+        state.check(vec!["b", "g"]);
+        let buffer = render(13, 7, &mut state);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "☐ Alfa       ",
+            "▼ Bravo      ",
+            "  ☑ Charlie  ",
+            "  ▶ Delta    ",
+            "  ☑ Golf     ",
+            "☐ Hotel      ",
+            "             ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn depth_one() {
+        let mut state = CheckTreeState::default();
+        state.open(vec!["b"]);
+        let buffer = render(13, 7, &mut state);
+        let expected = Buffer::with_lines([
+            "☐ Alfa       ",
+            "▼ Bravo      ",
+            "  ☐ Charlie  ",
+            "  ▶ Delta    ",
+            "  ☐ Golf     ",
+            "☐ Hotel      ",
+            "             ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn depth_two() {
+        let mut state = CheckTreeState::default();
+        state.open(vec!["b"]);
+        state.open(vec!["b", "d"]);
+        let buffer = render(15, 9, &mut state);
+        let expected = Buffer::with_lines([
+            "☐ Alfa         ",
+            "▼ Bravo        ",
+            "  ☐ Charlie    ",
+            "  ▼ Delta      ",
+            "    ☐ Echo     ",
+            "    ☐ Foxtrot  ",
+            "  ☐ Golf       ",
+            "☐ Hotel        ",
+            "               ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+}

--- a/tui/src/ui/widgets/tree/state.rs
+++ b/tui/src/ui/widgets/tree/state.rs
@@ -7,8 +7,9 @@ use super::{
     item::CheckTreeItem,
 };
 
-/// Keeps the state of what is currently selected and what was opened in a [`CheckTree`](super::Tree)
+/// Keeps the state of what is currently selected and what was opened in a [`CheckTree`](super::CheckTree)
 #[derive(Debug, Default)]
+#[allow(clippy::module_name_repetitions)]
 pub struct CheckTreeState<Identifier> {
     pub(super) offset: usize,
     pub(super) opened: HashSet<Vec<Identifier>>,
@@ -24,6 +25,7 @@ pub struct CheckTreeState<Identifier> {
     pub(super) last_rendered_identifiers: Vec<(u16, Vec<Identifier>)>,
 }
 
+#[allow(dead_code)]
 impl<Identifier> CheckTreeState<Identifier>
 where
     Identifier: Clone + PartialEq + Eq + core::hash::Hash,
@@ -46,11 +48,11 @@ where
 
     /// Refers to the current checked items.
     #[must_use]
-    pub fn checked(&self) -> &HashSet<Vec<Identifier>> {
+    pub const fn checked(&self) -> &HashSet<Vec<Identifier>> {
         &self.checked
     }
 
-    /// Get a flat list of all currently viewable (including by scrolling) [`TreeItem`]s with this `TreeState`.
+    /// Get a flat list of all currently viewable (including by scrolling) [`CheckTreeItem`]s with this `CheckTreeState`.
     #[must_use]
     pub fn flatten<'text>(
         &self,
@@ -64,12 +66,6 @@ where
     /// Returns `true` when the selection changed.
     ///
     /// Clear the selection by passing an empty identifier vector:
-    ///
-    /// ```rust
-    /// # use tui_tree_widget::TreeState;
-    /// # let mut state = TreeState::<usize>::default();
-    /// state.select(Vec::new());
-    /// ```
     pub fn select(&mut self, identifier: Vec<Identifier>) -> bool {
         self.ensure_selected_in_view_on_next_render = true;
         let changed = self.selected != identifier;
@@ -262,7 +258,7 @@ where
         }
     }
 
-    /// Ensure the selected [`TreeItem`] is in view on next render
+    /// Ensure the selected [`CheckTreeItem`] is in view on next render
     pub fn scroll_selected_into_view(&mut self) {
         self.ensure_selected_in_view_on_next_render = true;
     }
@@ -280,7 +276,7 @@ where
     /// Scroll the specified amount of lines down
     ///
     /// Returns `true` when the scroll position changed.
-    /// Returns `false` when the scrolling has reached the last [`TreeItem`].
+    /// Returns `false` when the scrolling has reached the last [`CheckTreeItem`].
     pub fn scroll_down(&mut self, lines: usize) -> bool {
         let before = self.offset;
         self.offset = self

--- a/tui/src/ui/widgets/tree/state.rs
+++ b/tui/src/ui/widgets/tree/state.rs
@@ -33,18 +33,6 @@ where
         self.offset
     }
 
-    // #[must_use]
-    // fn is_identifier_a_leaf(&self, identifier: &[Identifier]) -> bool {
-    //     let mut items = self.items.clone();
-    //     for id in identifier {
-    //         let Some(item) = items.iter().find(|item| item.identifier() == id) else {
-    //             return false;
-    //         };
-    //         items = item.children();
-    //     }
-    //     items.is_empty()
-    // }
-
     #[must_use]
     pub const fn opened(&self) -> &HashSet<Vec<Identifier>> {
         &self.opened

--- a/tui/src/ui/widgets/tree/state.rs
+++ b/tui/src/ui/widgets/tree/state.rs
@@ -1,0 +1,364 @@
+use std::collections::HashSet;
+
+use ratatui::layout::{Position, Rect};
+
+use super::{
+    flatten::{flatten, Flattened},
+    item::CheckTreeItem,
+};
+
+/// Keeps the state of what is currently selected and what was opened in a [`CheckTree`](super::Tree)
+#[derive(Debug, Default)]
+pub struct CheckTreeState<Identifier> {
+    pub(super) offset: usize,
+    pub(super) opened: HashSet<Vec<Identifier>>,
+    pub(super) selected: Vec<Identifier>,
+    pub(super) checked: HashSet<Vec<Identifier>>,
+    pub(super) ensure_selected_in_view_on_next_render: bool,
+
+    pub(super) last_area: Rect,
+    pub(super) last_biggest_index: usize,
+    /// All identifiers open on last render
+    pub(super) last_identifiers: Vec<Vec<Identifier>>,
+    /// Identifier rendered at `y` on last render
+    pub(super) last_rendered_identifiers: Vec<(u16, Vec<Identifier>)>,
+}
+
+impl<Identifier> CheckTreeState<Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    #[must_use]
+    pub const fn get_offset(&self) -> usize {
+        self.offset
+    }
+
+    // #[must_use]
+    // fn is_identifier_a_leaf(&self, identifier: &[Identifier]) -> bool {
+    //     let mut items = self.items.clone();
+    //     for id in identifier {
+    //         let Some(item) = items.iter().find(|item| item.identifier() == id) else {
+    //             return false;
+    //         };
+    //         items = item.children();
+    //     }
+    //     items.is_empty()
+    // }
+
+    #[must_use]
+    pub const fn opened(&self) -> &HashSet<Vec<Identifier>> {
+        &self.opened
+    }
+
+    /// Refers to the current cursor selection.
+    #[must_use]
+    pub fn selected(&self) -> &[Identifier] {
+        &self.selected
+    }
+
+    /// Refers to the current checked items.
+    #[must_use]
+    pub fn checked(&self) -> &HashSet<Vec<Identifier>> {
+        &self.checked
+    }
+
+    /// Get a flat list of all currently viewable (including by scrolling) [`TreeItem`]s with this `TreeState`.
+    #[must_use]
+    pub fn flatten<'text>(
+        &self,
+        items: &'text [CheckTreeItem<'text, Identifier>],
+    ) -> Vec<Flattened<'text, Identifier>> {
+        flatten(&self.opened, items, &[])
+    }
+
+    /// Selects the given identifier.
+    ///
+    /// Returns `true` when the selection changed.
+    ///
+    /// Clear the selection by passing an empty identifier vector:
+    ///
+    /// ```rust
+    /// # use tui_tree_widget::TreeState;
+    /// # let mut state = TreeState::<usize>::default();
+    /// state.select(Vec::new());
+    /// ```
+    pub fn select(&mut self, identifier: Vec<Identifier>) -> bool {
+        self.ensure_selected_in_view_on_next_render = true;
+        let changed = self.selected != identifier;
+        self.selected = identifier;
+        changed
+    }
+
+    /// Open a tree node.
+    /// Returns `true` when it was closed and has been opened.
+    /// Returns `false` when it was already open.
+    pub fn open(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else {
+            self.opened.insert(identifier)
+        }
+    }
+
+    /// Close a tree node.
+    /// Returns `true` when it was open and has been closed.
+    /// Returns `false` when it was already closed.
+    pub fn close(&mut self, identifier: &[Identifier]) -> bool {
+        self.opened.remove(identifier)
+    }
+
+    /// Check a tree node
+    /// Returns `true` when it was unchecked and has been checked.
+    /// Returns `false` when it was already checked.
+    pub fn check(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else {
+            // insert the identifier
+            self.checked.insert(identifier)
+        }
+    }
+
+    /// Uncheck a tree node
+    /// Returns `true` when it was checked and has been unchecked.
+    /// Returns `false` when it was already unchecked.
+    pub fn uncheck(&mut self, identifier: &[Identifier]) -> bool {
+        self.checked.remove(identifier)
+    }
+
+    /// Toggles a tree node open/close state.
+    /// When it is currently open, then [`close`](Self::close) is called. Otherwise [`open`](Self::open).
+    ///
+    /// Returns `true` when a node is opened / closed.
+    /// As toggle always changes something, this only returns `false` when an empty identifier is given.
+    pub fn toggle(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else if self.opened.contains(&identifier) {
+            self.close(&identifier)
+        } else {
+            self.open(identifier)
+        }
+    }
+
+    /// Toggles the currently selected tree node open/close state.
+    /// See also [`toggle`](Self::toggle)
+    ///
+    /// Returns `true` when a node is opened / closed.
+    /// As toggle always changes something, this only returns `false` when nothing is selected.
+    pub fn toggle_selected(&mut self) -> bool {
+        if self.selected.is_empty() {
+            return false;
+        }
+
+        self.ensure_selected_in_view_on_next_render = true;
+
+        // Reimplement self.close because of multiple different borrows
+        let was_open = self.opened.remove(&self.selected);
+        if was_open {
+            return true;
+        }
+
+        self.open(self.selected.clone())
+    }
+
+    /// Toggles a tree node checked/unchecked state.
+    /// When it is currently checked, then [`uncheck`](Self::uncheck) is called. Otherwise [`check`](Self::check).
+    ///
+    /// Returns `true` when a node is checked / unchecked.
+    /// As toggle always changes something, this only returns `false` when an empty identifier is given.
+    pub fn toggle_check(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else if self.checked.contains(&identifier) {
+            self.uncheck(&identifier)
+        } else {
+            self.check(identifier)
+        }
+    }
+
+    /// Toggles the currently selected tree node checked/unchecked state.
+    /// See also [`toggle_check`](Self::toggle_check)
+    /// Returns `true` when a node is checked / unchecked.
+    /// As toggle always changes something, this only returns `false` when nothing is selected.
+    pub fn toggle_check_selected(&mut self) -> bool {
+        if self.selected.is_empty() {
+            return false;
+        }
+
+        // Reimplement self.uncheck because of multiple different borrows
+        let was_checked = self.checked.remove(&self.selected);
+        if was_checked {
+            return true;
+        }
+
+        self.check(self.selected.clone())
+    }
+
+    /// Closes all open nodes.
+    ///
+    /// Returns `true` when any node was closed.
+    pub fn close_all(&mut self) -> bool {
+        if self.opened.is_empty() {
+            false
+        } else {
+            self.opened.clear();
+            true
+        }
+    }
+
+    /// Select the first node.
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn select_first(&mut self) -> bool {
+        let identifier = self.last_identifiers.first().cloned().unwrap_or_default();
+        self.select(identifier)
+    }
+
+    /// Select the last node.
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn select_last(&mut self) -> bool {
+        let new_identifier = self.last_identifiers.last().cloned().unwrap_or_default();
+        self.select(new_identifier)
+    }
+
+    /// Move the current selection with the direction/amount by the given function.
+    ///
+    /// Returns `true` when the selection changed.
+    ///
+    /// For more examples take a look into the source code of [`key_up`](Self::key_up) or [`key_down`](Self::key_down).
+    /// They are implemented with this method.
+    pub fn select_relative<F>(&mut self, change_function: F) -> bool
+    where
+        F: FnOnce(Option<usize>) -> usize,
+    {
+        let identifiers = &self.last_identifiers;
+        let current_identifier = &self.selected;
+        let current_index = identifiers
+            .iter()
+            .position(|identifier| identifier == current_identifier);
+        let new_index = change_function(current_index).min(self.last_biggest_index);
+        let new_identifier = identifiers.get(new_index).cloned().unwrap_or_default();
+        self.select(new_identifier)
+    }
+
+    /// Get the identifier that was rendered for the given position on last render.
+    #[must_use]
+    pub fn rendered_at(&self, position: Position) -> Option<&[Identifier]> {
+        if !self.last_area.contains(position) {
+            return None;
+        }
+
+        self.last_rendered_identifiers
+            .iter()
+            .rev()
+            .find(|(y, _)| position.y >= *y)
+            .map(|(_, identifier)| identifier.as_ref())
+    }
+
+    /// Select what was rendered at the given position on last render.
+    /// When it is already selected, toggle it.
+    ///
+    /// Returns `true` when the state changed.
+    /// Returns `false` when there was nothing at the given position.
+    pub fn click_at(&mut self, position: Position) -> bool {
+        if let Some(identifier) = self.rendered_at(position) {
+            if identifier == self.selected {
+                self.toggle_selected()
+            } else {
+                self.select(identifier.to_vec())
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Ensure the selected [`TreeItem`] is in view on next render
+    pub fn scroll_selected_into_view(&mut self) {
+        self.ensure_selected_in_view_on_next_render = true;
+    }
+
+    /// Scroll the specified amount of lines up
+    ///
+    /// Returns `true` when the scroll position changed.
+    /// Returns `false` when the scrolling has reached the top.
+    pub fn scroll_up(&mut self, lines: usize) -> bool {
+        let before = self.offset;
+        self.offset = self.offset.saturating_sub(lines);
+        before != self.offset
+    }
+
+    /// Scroll the specified amount of lines down
+    ///
+    /// Returns `true` when the scroll position changed.
+    /// Returns `false` when the scrolling has reached the last [`TreeItem`].
+    pub fn scroll_down(&mut self, lines: usize) -> bool {
+        let before = self.offset;
+        self.offset = self
+            .offset
+            .saturating_add(lines)
+            .min(self.last_biggest_index);
+        before != self.offset
+    }
+
+    /// Handles the up arrow key.
+    /// Moves up in the current depth or to its parent.
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn key_up(&mut self) -> bool {
+        self.select_relative(|current| {
+            // When nothing is selected, fall back to end
+            current.map_or(usize::MAX, |current| current.saturating_sub(1))
+        })
+    }
+
+    /// Handles the down arrow key.
+    /// Moves down in the current depth or into a child node.
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn key_down(&mut self) -> bool {
+        self.select_relative(|current| {
+            // When nothing is selected, fall back to start
+            current.map_or(0, |current| current.saturating_add(1))
+        })
+    }
+
+    /// Handles the left arrow key.
+    /// Closes the currently selected or moves to its parent.
+    ///
+    /// Returns `true` when the selection or the open state changed.
+    pub fn key_left(&mut self) -> bool {
+        self.ensure_selected_in_view_on_next_render = true;
+        // Reimplement self.close because of multiple different borrows
+        let mut changed = self.opened.remove(&self.selected);
+        if !changed {
+            // Select the parent by removing the leaf from selection
+            let popped = self.selected.pop();
+            changed = popped.is_some();
+        }
+        changed
+    }
+
+    /// Handles the right arrow key.
+    /// Opens the currently selected.
+    ///
+    /// Returns `true` when it was closed and has been opened.
+    /// Returns `false` when it was already open or nothing being selected.
+    pub fn key_right(&mut self) -> bool {
+        if self.selected.is_empty() {
+            false
+        } else {
+            self.ensure_selected_in_view_on_next_render = true;
+            self.open(self.selected.clone())
+        }
+    }
+
+    /// Handles the space key.
+    /// Toggles the whether the current item is selected
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn key_space(&mut self) -> bool {
+        self.toggle_check_selected()
+    }
+}


### PR DESCRIPTION
Summary:

- Implements the CheckTree widget as a drop-in replacement for tui_tree_widget's Tree widget.
- Update the content view components to use the new CheckTree widget.
- Update the content view components with instructions / indicators to cover operating on "checked" items.
- Update the content view components to fully utilize the functionality of the new CheckTree widget.