### PR TITLE
fix(audio): Use saturating_add and saturating_sub for seek calculations

### DIFF
--- a/core/src/audio/mod.rs
+++ b/core/src/audio/mod.rs
@@ -590,8 +590,8 @@ impl AudioKernel {
         // calculate the new time based on the seek type
         let new_time = match seek {
             SeekType::Absolute => duration,
-            SeekType::RelativeForwards => duration_info.time_played + duration,
-            SeekType::RelativeBackwards => duration_info.time_played - duration,
+            SeekType::RelativeForwards => duration_info.time_played.saturating_add(duration),
+            SeekType::RelativeBackwards => duration_info.time_played.saturating_sub(duration),
         };
         let new_time = if new_time > duration_info.current_duration {
             duration_info.current_duration


### PR DESCRIPTION
fixes #68 

Replace the addition and subtraction operators with the `saturating_add` and `saturating_sub` methods to handle seek calculations in the `AudioKernel` implementation. This ensures that the new time remains within the bounds of the current duration, preventing any potential out-of-range errors.