### PR TITLE
feat(tui): add random view and integrate into sidebar and state management

### DIFF
--- a/tui/src/test_utils.rs
+++ b/tui/src/test_utils.rs
@@ -10,7 +10,7 @@ use crate::{
     ui::{
         components::content_view::views::{
             AlbumViewProps, ArtistViewProps, CollectionViewProps, PlaylistViewProps,
-            RadioViewProps, SongViewProps, ViewData,
+            RadioViewProps, RandomViewProps, SongViewProps, ViewData,
         },
         AppState,
     },
@@ -112,6 +112,11 @@ pub fn state_with_everything() -> AppState {
             collections: vec![collection.clone()].into_boxed_slice(),
         },
         additional_view_data: ViewData {
+            random: Some(RandomViewProps {
+                album: album_id.clone(),
+                artist: artist_id.clone(),
+                song: song_id.clone(),
+            }),
             album: Some(AlbumViewProps {
                 id: album_id,
                 album: album.clone(),

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -20,6 +20,7 @@ pub mod generic;
 pub mod none;
 pub mod playlist;
 pub mod radio;
+pub mod random;
 pub mod search;
 pub mod song;
 pub mod sort_mode;
@@ -37,6 +38,7 @@ pub struct ViewData {
     pub playlist: Option<PlaylistViewProps>,
     pub song: Option<SongViewProps>,
     pub radio: Option<RadioViewProps>,
+    pub random: Option<RandomViewProps>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -306,6 +308,16 @@ pub struct RadioViewProps {
     pub count: u32,
     /// The songs that are similar to the things
     pub songs: Box<[Song]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RandomViewProps {
+    /// id of a random album
+    pub album: Thing,
+    /// id of a random artist
+    pub artist: Thing,
+    /// id of a random song
+    pub song: Thing,
 }
 
 pub mod checktree_utils {

--- a/tui/src/ui/components/content_view/views/random.rs
+++ b/tui/src/ui/components/content_view/views/random.rs
@@ -156,7 +156,7 @@ impl Component for RandomView {
                 // adjust the mouse position so that it is relative to the area of the list
                 let adjusted_mouse_y = mouse_position.y - area.y;
 
-                // select the item at teh mouse position
+                // select the item at the mouse position
                 let selected = adjusted_mouse_y as usize;
                 if self.random_type_list.selected() == Some(selected) {
                     self.handle_key_event(KeyEvent::from(KeyCode::Enter));

--- a/tui/src/ui/components/content_view/views/random.rs
+++ b/tui/src/ui/components/content_view/views/random.rs
@@ -1,0 +1,509 @@
+//! implementation of the random view
+
+use std::fmt::Display;
+
+use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::{
+    layout::{Alignment, Margin, Position, Rect},
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, List, ListItem, ListState},
+    Frame,
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::RandomViewProps;
+use crate::{
+    state::action::{Action, ViewAction},
+    ui::{
+        colors::{BORDER_FOCUSED, BORDER_UNFOCUSED, TEXT_HIGHLIGHT, TEXT_NORMAL},
+        components::{content_view::ActiveView, Component, ComponentRender, RenderProps},
+        AppState,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// The type of random item to get
+pub enum ItemType {
+    Album,
+    Artist,
+    Song,
+}
+
+impl ItemType {
+    #[must_use]
+    pub fn to_action(&self, props: &RandomViewProps) -> Option<Action> {
+        match self {
+            Self::Album => Some(Action::ActiveView(ViewAction::Set(ActiveView::Album(
+                props.album.id.clone(),
+            )))),
+            Self::Artist => Some(Action::ActiveView(ViewAction::Set(ActiveView::Artist(
+                props.artist.id.clone(),
+            )))),
+            Self::Song => Some(Action::ActiveView(ViewAction::Set(ActiveView::Song(
+                props.song.id.clone(),
+            )))),
+        }
+    }
+}
+
+impl Display for ItemType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Album => write!(f, "Random Album"),
+            Self::Artist => write!(f, "Random Artist"),
+            Self::Song => write!(f, "Random Song"),
+        }
+    }
+}
+
+const RANDOM_TYPE_ITEMS: [ItemType; 3] = [ItemType::Album, ItemType::Artist, ItemType::Song];
+
+#[allow(clippy::module_name_repetitions)]
+pub struct RandomView {
+    /// Action Sender
+    pub action_tx: UnboundedSender<Action>,
+    /// Props for the random view
+    pub props: Option<RandomViewProps>,
+    /// State of the list that users interact with to a random item of the selected type
+    random_type_list: ListState,
+}
+
+impl Component for RandomView {
+    fn new(state: &AppState, action_tx: UnboundedSender<Action>) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            action_tx,
+            props: state.additional_view_data.random.clone(),
+            random_type_list: ListState::default(),
+        }
+    }
+
+    fn move_with_state(self, state: &AppState) -> Self
+    where
+        Self: Sized,
+    {
+        if let Some(props) = &state.additional_view_data.random {
+            Self {
+                props: Some(props.clone()),
+                ..self
+            }
+        } else {
+            self
+        }
+    }
+
+    fn name(&self) -> &str {
+        "Random"
+    }
+
+    fn handle_key_event(&mut self, key: KeyEvent) {
+        match key.code {
+            // Move the selection up
+            KeyCode::Up => {
+                if let Some(selected) = self.random_type_list.selected() {
+                    let selected = if selected == 0 {
+                        RANDOM_TYPE_ITEMS.len() - 1
+                    } else {
+                        selected - 1
+                    };
+                    self.random_type_list.select(Some(selected));
+                } else {
+                    self.random_type_list
+                        .select(Some(RANDOM_TYPE_ITEMS.len() - 1));
+                }
+            }
+            // Move the selection down
+            KeyCode::Down => {
+                if let Some(selected) = self.random_type_list.selected() {
+                    let selected = if selected == RANDOM_TYPE_ITEMS.len() - 1 {
+                        0
+                    } else {
+                        selected + 1
+                    };
+                    self.random_type_list.select(Some(selected));
+                } else {
+                    self.random_type_list.select(Some(0));
+                }
+            }
+            // Select the current item
+            KeyCode::Enter => {
+                if let Some(selected) = self.random_type_list.selected() {
+                    if let Some(action) = RANDOM_TYPE_ITEMS.get(selected).and_then(|item| {
+                        self.props.as_ref().and_then(|props| item.to_action(props))
+                    }) {
+                        self.action_tx.send(action).unwrap();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_mouse_event(&mut self, mouse: MouseEvent, area: Rect) {
+        let MouseEvent {
+            kind, column, row, ..
+        } = mouse;
+        let mouse_position = Position::new(column, row);
+
+        // adjust area to exclude the border
+        let area = area.inner(Margin::new(1, 1));
+
+        match kind {
+            MouseEventKind::Down(MouseButton::Left) if area.contains(mouse_position) => {
+                // adjust the mouse position so that it is relative to the area of the list
+                let adjusted_mouse_y = mouse_position.y - area.y;
+
+                // select the item at teh mouse position
+                let selected = adjusted_mouse_y as usize;
+                if self.random_type_list.selected() == Some(selected) {
+                    self.handle_key_event(KeyEvent::from(KeyCode::Enter));
+                } else {
+                    self.random_type_list.select(Some(selected));
+                }
+            }
+            MouseEventKind::ScrollDown => self.handle_key_event(KeyEvent::from(KeyCode::Down)),
+            MouseEventKind::ScrollUp => self.handle_key_event(KeyEvent::from(KeyCode::Up)),
+            _ => {}
+        }
+    }
+}
+
+impl ComponentRender<RenderProps> for RandomView {
+    fn render_border(&self, frame: &mut Frame, props: RenderProps) -> RenderProps {
+        let border_style = if props.is_focused {
+            Style::default().fg(BORDER_FOCUSED.into())
+        } else {
+            Style::default().fg(BORDER_UNFOCUSED.into())
+        };
+
+        let border = Block::bordered()
+            .title_top("Random")
+            .title_bottom(" \u{23CE} : select | ↑/↓: Move ")
+            .border_style(border_style);
+        frame.render_widget(&border, props.area);
+        let area = border.inner(props.area);
+
+        RenderProps { area, ..props }
+    }
+
+    fn render_content(&self, frame: &mut Frame, props: RenderProps) {
+        if self.props.is_some() {
+            let items = RANDOM_TYPE_ITEMS
+                .iter()
+                .map(|item| {
+                    ListItem::new(
+                        Span::styled(item.to_string(), Style::default().fg(TEXT_NORMAL.into()))
+                            .into_centered_line(),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            frame.render_stateful_widget(
+                List::new(items).highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold()),
+                props.area,
+                &mut self.random_type_list.clone(),
+            );
+        } else {
+            frame.render_widget(
+                Line::from("Random items unavailable")
+                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .alignment(Alignment::Center),
+                props.area,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::{assert_buffer_eq, setup_test_terminal, state_with_everything},
+        ui::components::content_view::ActiveView,
+    };
+    use anyhow::Result;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+    use mecomp_storage::db::schemas::{album::Album, artist::Artist, song::Song};
+    use pretty_assertions::assert_eq;
+    use ratatui::buffer::Buffer;
+
+    #[test]
+    fn test_random_view_type_to_action() {
+        let props = RandomViewProps {
+            album: Album::generate_id().into(),
+            artist: Artist::generate_id().into(),
+            song: Song::generate_id().into(),
+        };
+
+        assert_eq!(
+            ItemType::Album.to_action(&props),
+            Some(Action::ActiveView(ViewAction::Set(ActiveView::Album(
+                props.album.id.clone()
+            ))))
+        );
+        assert_eq!(
+            ItemType::Artist.to_action(&props),
+            Some(Action::ActiveView(ViewAction::Set(ActiveView::Artist(
+                props.artist.id.clone()
+            ))))
+        );
+        assert_eq!(
+            ItemType::Song.to_action(&props),
+            Some(Action::ActiveView(ViewAction::Set(ActiveView::Song(
+                props.song.id.clone()
+            ))))
+        );
+    }
+
+    #[test]
+    fn test_random_view_type_display() {
+        assert_eq!(ItemType::Album.to_string(), "Random Album");
+        assert_eq!(ItemType::Artist.to_string(), "Random Artist");
+        assert_eq!(ItemType::Song.to_string(), "Random Song");
+    }
+
+    #[test]
+    fn test_new() {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let state = state_with_everything();
+        let view = RandomView::new(&state, tx);
+
+        assert_eq!(view.name(), "Random");
+        assert!(view.props.is_some());
+        assert_eq!(view.props, state.additional_view_data.random);
+    }
+
+    #[test]
+    fn test_move_with_state() {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let state = AppState::default();
+        let new_state = state_with_everything();
+        let view = RandomView::new(&state, tx).move_with_state(&new_state);
+
+        assert!(view.props.is_some());
+        assert_eq!(view.props, new_state.additional_view_data.random);
+    }
+
+    #[test]
+    /// Test rendering when there are no items available (e.g., empty library)
+    fn test_render_empty() -> Result<()> {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let view = RandomView::new(&AppState::default(), tx);
+
+        let (mut terminal, area) = setup_test_terminal(29, 3);
+        let props = RenderProps {
+            area,
+            is_focused: true,
+        };
+        let buffer = terminal
+            .draw(|frame| view.render(frame, props))
+            .unwrap()
+            .buffer
+            .clone();
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┌Random─────────────────────┐",
+            "│ Random items unavailable  │",
+            "└ ⏎ : select | ↑/↓: Move ───┘",
+        ]);
+
+        assert_buffer_eq(&buffer, &expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_render() -> Result<()> {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let view = RandomView::new(&state_with_everything(), tx);
+
+        let (mut terminal, area) = setup_test_terminal(50, 5);
+        let props = RenderProps {
+            area,
+            is_focused: true,
+        };
+        let buffer = terminal
+            .draw(|frame| view.render(frame, props))
+            .unwrap()
+            .buffer
+            .clone();
+        let expected = Buffer::with_lines([
+            "┌Random──────────────────────────────────────────┐",
+            "│                  Random Album                  │",
+            "│                 Random Artist                  │",
+            "│                  Random Song                   │",
+            "└ ⏎ : select | ↑/↓: Move ────────────────────────┘",
+        ]);
+
+        assert_buffer_eq(&buffer, &expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_navigation_wraps() {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let mut view = RandomView::new(&state_with_everything(), tx);
+
+        view.handle_key_event(KeyEvent::from(KeyCode::Up));
+        assert_eq!(
+            view.random_type_list.selected(),
+            Some(RANDOM_TYPE_ITEMS.len() - 1)
+        );
+
+        view.handle_key_event(KeyEvent::from(KeyCode::Down));
+        assert_eq!(view.random_type_list.selected(), Some(0));
+    }
+
+    #[test]
+    fn test_actions() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let state = state_with_everything();
+        let mut view = RandomView::new(&state, tx);
+        let random_view_props = state.additional_view_data.random.clone().unwrap();
+
+        view.handle_key_event(KeyEvent::from(KeyCode::Down));
+        view.handle_key_event(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Album(
+                random_view_props.album.id,
+            )))
+        );
+
+        view.handle_key_event(KeyEvent::from(KeyCode::Down));
+        view.handle_key_event(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Artist(
+                random_view_props.artist.id,
+            )))
+        );
+
+        view.handle_key_event(KeyEvent::from(KeyCode::Down));
+        view.handle_key_event(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(
+                ActiveView::Song(random_view_props.song.id,)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_mouse() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let state = state_with_everything();
+        let mut view = RandomView::new(&state, tx);
+        let random_view_props = state.additional_view_data.random.clone().unwrap();
+        let view_area = Rect::new(0, 0, 50, 5);
+
+        // select the first item by scrolling down
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 25,
+                row: 1,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        // click selected item
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 1,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Album(
+                random_view_props.album.id.clone(),
+            )))
+        );
+
+        // select the second item by scrolling down
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 25,
+                row: 1,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        // click selected item
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 2,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Artist(
+                random_view_props.artist.id,
+            )))
+        );
+
+        // select the first item by clicking on it
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 1,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        // click selected item
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 1,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Album(
+                random_view_props.album.id,
+            )))
+        );
+
+        // select the third item by clicking on it
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 3,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        view.handle_mouse_event(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 25,
+                row: 3,
+                modifiers: KeyModifiers::empty(),
+            },
+            view_area,
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Song(random_view_props.song.id)))
+        );
+    }
+}

--- a/tui/src/ui/components/sidebar.rs
+++ b/tui/src/ui/components/sidebar.rs
@@ -46,6 +46,7 @@ pub enum SidebarItem {
     Albums,
     Playlists,
     Collections,
+    Random,
     Space, // this is used to create space between the library actions and the other items
     LibraryRescan,
     LibraryAnalyze,
@@ -57,15 +58,16 @@ impl SidebarItem {
     pub const fn to_action(&self) -> Option<Action> {
         match self {
             Self::Search => Some(Action::ActiveView(ViewAction::Set(ActiveView::Search))),
-            Self::LibraryRescan => Some(Action::Library(LibraryAction::Rescan)),
-            Self::LibraryAnalyze => Some(Action::Library(LibraryAction::Analyze)),
-            Self::LibraryRecluster => Some(Action::Library(LibraryAction::Recluster)),
             Self::Songs => Some(Action::ActiveView(ViewAction::Set(ActiveView::Songs))),
             Self::Artists => Some(Action::ActiveView(ViewAction::Set(ActiveView::Artists))),
             Self::Albums => Some(Action::ActiveView(ViewAction::Set(ActiveView::Albums))),
             Self::Playlists => Some(Action::ActiveView(ViewAction::Set(ActiveView::Playlists))),
             Self::Collections => Some(Action::ActiveView(ViewAction::Set(ActiveView::Collections))),
+            Self::Random => Some(Action::ActiveView(ViewAction::Set(ActiveView::Random))),
             Self::Space => None,
+            Self::LibraryRescan => Some(Action::Library(LibraryAction::Rescan)),
+            Self::LibraryAnalyze => Some(Action::Library(LibraryAction::Analyze)),
+            Self::LibraryRecluster => Some(Action::Library(LibraryAction::Recluster)),
         }
     }
 }
@@ -74,20 +76,21 @@ impl Display for SidebarItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Search => write!(f, "Search"),
-            Self::LibraryRescan => write!(f, "Library Rescan"),
-            Self::LibraryAnalyze => write!(f, "Library Analyze"),
             Self::Songs => write!(f, "Songs"),
             Self::Artists => write!(f, "Artists"),
             Self::Albums => write!(f, "Albums"),
             Self::Playlists => write!(f, "Playlists"),
             Self::Collections => write!(f, "Collections"),
+            Self::Random => write!(f, "Random"),
             Self::Space => write!(f, ""),
+            Self::LibraryRescan => write!(f, "Library Rescan"),
+            Self::LibraryAnalyze => write!(f, "Library Analyze"),
             Self::LibraryRecluster => write!(f, "Library Recluster"),
         }
     }
 }
 
-const SIDEBAR_ITEMS: [SidebarItem; 11] = [
+const SIDEBAR_ITEMS: [SidebarItem; 12] = [
     SidebarItem::Search,
     SidebarItem::Space,
     SidebarItem::Songs,
@@ -95,6 +98,7 @@ const SIDEBAR_ITEMS: [SidebarItem; 11] = [
     SidebarItem::Albums,
     SidebarItem::Playlists,
     SidebarItem::Collections,
+    SidebarItem::Random,
     SidebarItem::Space,
     SidebarItem::LibraryRescan,
     SidebarItem::LibraryAnalyze,
@@ -286,6 +290,7 @@ mod tests {
         assert_eq!(SidebarItem::Albums.to_string(), "Albums");
         assert_eq!(SidebarItem::Playlists.to_string(), "Playlists");
         assert_eq!(SidebarItem::Collections.to_string(), "Collections");
+        assert_eq!(SidebarItem::Random.to_string(), "Random");
         assert_eq!(SidebarItem::Space.to_string(), "");
         assert_eq!(
             SidebarItem::LibraryRecluster.to_string(),
@@ -301,7 +306,7 @@ mod tests {
             ..state_with_everything()
         });
 
-        let (mut terminal, area) = setup_test_terminal(19, 14);
+        let (mut terminal, area) = setup_test_terminal(19, 15);
         let props = RenderProps {
             area,
             is_focused: true,
@@ -316,6 +321,7 @@ mod tests {
             "│Albums           │",
             "│Playlists        │",
             "│Collections      │",
+            "│Random           │",
             "│                 │",
             "│Library Rescan   │",
             "│Library Analyze  │",
@@ -393,6 +399,13 @@ mod tests {
         assert_eq!(
             rx.blocking_recv().unwrap(),
             Action::ActiveView(ViewAction::Set(ActiveView::Collections))
+        );
+
+        sidebar.handle_key_event(KeyEvent::from(KeyCode::Down));
+        sidebar.handle_key_event(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            Action::ActiveView(ViewAction::Set(ActiveView::Random))
         );
 
         sidebar.handle_key_event(KeyEvent::from(KeyCode::Down));

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -21,7 +21,7 @@ use components::{
     content_view::{
         views::{
             AlbumViewProps, ArtistViewProps, CollectionViewProps, PlaylistViewProps,
-            RadioViewProps, SongViewProps, ViewData,
+            RadioViewProps, RandomViewProps, SongViewProps, ViewData,
         },
         ActiveView,
     },
@@ -395,6 +395,27 @@ async fn handle_additional_view_data(
                 ..state.additional_view_data.clone()
             })
         }
+        ActiveView::Random => {
+            let random_view_props = if let Ok((Some(album), Some(artist), Some(song))) = tokio::try_join!(
+                daemon.rand_album(Context::current()),
+                daemon.rand_artist(Context::current()),
+                daemon.rand_song(Context::current()),
+            ) {
+                Some(RandomViewProps {
+                    album: album.id.into(),
+                    artist: artist.id.into(),
+                    song: song.id.into(),
+                })
+            } else {
+                None
+            };
+
+            Some(ViewData {
+                random: random_view_props,
+                ..state.additional_view_data.clone()
+            })
+        }
+
         ActiveView::None
         | ActiveView::Search
         | ActiveView::Songs


### PR DESCRIPTION
Whenever the view is set as the active content view, it queries the daemon for a random album, song, or artist, the results are stored in the component props.

The view displays 3 options to the user, "Random Album", "Random Artist", and "Random Song", that when clicked navigate to the view for the album/artist/song that it got as described above.

The view gets new random items every time it is set as the active content view, so if you navigate away and go back you'll have different items than before.

fixes #200