### PR TITLE
feat(testing): convert cli smoke tests to snapshot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "full"
+  CI: true
 
 concurrency:
   group: CI-${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1432,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2313,6 +2331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "similar",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,6 +2847,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
+ "insta",
  "mecomp-core",
  "mecomp-daemon",
  "mecomp-storage",
@@ -4901,6 +4938,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ lto = false
 strip = "none"
 opt-level = 1
 
+[profile.test.package]
+insta.opt-level = 3
+similar.opt-level = 3
+
 [profile.tarpaulin]
 inherits = "test"
 opt-level = 0

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ one-or-many = { workspace = true }
 mecomp-workspace-hack = { version = "0.1", path = "../mecomp-workspace-hack" }
 
 [dev-dependencies]
+insta = "1.42.0"
 pretty_assertions = { workspace = true }
 mecomp-core = { workspace = true, features = ["rpc", "mock_playback"] }
 mecomp-storage = { workspace = true, features = [

--- a/cli/src/handlers/implementations.rs
+++ b/cli/src/handlers/implementations.rs
@@ -460,7 +460,7 @@ impl CommandHandler for SeekCommand {
                         Duration::from_secs_f32(*amount),
                     )
                     .await?;
-                writeln!(stdout, "Daemon response:\nseeked forward by {amount:.2}s")?;
+                writeln!(stdout, "Daemon response:\nsought forward by {amount:.2}s")?;
             }
             Self::Backward { amount } => {
                 client
@@ -470,7 +470,7 @@ impl CommandHandler for SeekCommand {
                         Duration::from_secs_f32(*amount),
                     )
                     .await?;
-                writeln!(stdout, "Daemon response:\nseeked backward by {amount:.2}s")?;
+                writeln!(stdout, "Daemon response:\nsought backward by {amount:.2}s")?;
             }
             Self::Absolute { position } => {
                 client
@@ -478,7 +478,7 @@ impl CommandHandler for SeekCommand {
                     .await?;
                 writeln!(
                     stdout,
-                    "Daemon response:\nseeked to position {position:.2}s"
+                    "Daemon response:\nsought to position {position:.2}s"
                 )?;
             }
         }

--- a/cli/src/handlers/mod.rs
+++ b/cli/src/handlers/mod.rs
@@ -10,10 +10,12 @@ use clap::{Subcommand, ValueEnum};
 pub trait CommandHandler {
     type Output;
 
-    async fn handle(
+    async fn handle<W1: std::fmt::Write + Send, W2: std::fmt::Write + Send>(
         &self,
         ctx: tarpc::context::Context,
         client: mecomp_core::rpc::MusicPlayerClient,
+        stdout: &mut W1,
+        stderr: &mut W2,
     ) -> Self::Output;
 }
 

--- a/cli/src/handlers/smoke_tests.rs
+++ b/cli/src/handlers/smoke_tests.rs
@@ -140,6 +140,14 @@ async fn client() -> MusicPlayerClient {
     init_test_client_server(db, settings, audio_kernel)
 }
 
+macro_rules! set_snapshot_suffix {
+    ($($expr:expr),*) => {
+        let mut settings = insta::Settings::clone_current();
+        settings.set_snapshot_suffix(format!($($expr,)*));
+        let _guard = settings.bind_to_scope();
+    }
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_ping_command(#[future] client: MusicPlayerClient) {
@@ -152,7 +160,9 @@ async fn test_ping_command(#[future] client: MusicPlayerClient) {
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -168,7 +178,9 @@ async fn test_stop_command(#[future] client: MusicPlayerClient) {
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -233,7 +245,9 @@ async fn test_library_command(
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -252,7 +266,9 @@ async fn test_status_command(#[future] client: MusicPlayerClient, #[case] comman
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -268,7 +284,9 @@ async fn test_state_command(#[future] client: MusicPlayerClient) {
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -287,7 +305,9 @@ async fn test_current_command(#[future] client: MusicPlayerClient, #[case] targe
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -306,7 +326,9 @@ async fn test_rand_command(#[future] client: MusicPlayerClient, #[case] target: 
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -330,7 +352,9 @@ async fn test_search_command(#[future] client: MusicPlayerClient, #[case] target
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -368,7 +392,9 @@ async fn test_playback_command(
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -393,7 +419,9 @@ async fn test_queue_command(#[future] client: MusicPlayerClient, #[case] command
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -420,7 +448,9 @@ async fn test_playlist_command(
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -428,7 +458,6 @@ async fn test_playlist_command(
 #[case(CollectionCommand::List)]
 #[case(CollectionCommand::Get { id: item_id().to_string() })]
 #[case(CollectionCommand::Recluster)]
-#[case(CollectionCommand::Freeze { id: Playlist::generate_id().id.to_string(), name: "Test Collection".to_string() })]
 #[tokio::test]
 async fn test_collection_command(
     #[future] client: MusicPlayerClient,
@@ -443,7 +472,34 @@ async fn test_collection_command(
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
+}
+
+#[rstest]
+#[tokio::test]
+/// this is a separate test because the returned value depends on when the test is run,
+/// the ulid of the new playlist if generated at runtime and will be different each time
+async fn test_collection_freeze(#[future] client: MusicPlayerClient) {
+    let ctx = tarpc::context::current();
+    let command = Command::Collection {
+        command: CollectionCommand::Freeze {
+            id: item_id().to_string(),
+            name: "Test Collection".to_string(),
+        },
+    };
+
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
+    assert!(result.is_ok());
+
+    let stdout = String::from_utf8(stdout.0.clone()).unwrap();
+    assert!(stdout.starts_with("Daemon response:\nplaylist:"));
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
@@ -463,6 +519,8 @@ async fn test_radio_command(#[future] client: MusicPlayerClient, #[case] command
     let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
 
+    set_snapshot_suffix!("stdout-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    set_snapshot_suffix!("stderr-{:?}", command);
     insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }

--- a/cli/src/handlers/smoke_tests.rs
+++ b/cli/src/handlers/smoke_tests.rs
@@ -16,10 +16,10 @@ use surrealdb::{engine::local::Db, sql::Thing, Surreal};
 use tempfile::tempdir;
 
 use crate::handlers::{
-    CollectionCommand, Command, CommandHandler, CurrentTarget, LibraryCommand, LibraryGetTarget,
-    LibraryListTarget, PlaybackCommand, PlaylistAddCommand, PlaylistCommand, PlaylistGetMethod,
-    QueueAddTarget, QueueCommand, RadioCommand, RandTarget, RepeatMode, SearchTarget, SeekCommand,
-    StatusCommand, VolumeCommand,
+    utils::WriteAdapter, CollectionCommand, Command, CommandHandler, CurrentTarget, LibraryCommand,
+    LibraryGetTarget, LibraryListTarget, PlaybackCommand, PlaylistAddCommand, PlaylistCommand,
+    PlaylistGetMethod, QueueAddTarget, QueueCommand, RadioCommand, RandTarget, RepeatMode,
+    SearchTarget, SeekCommand, StatusCommand, VolumeCommand,
 };
 
 #[test]
@@ -146,8 +146,14 @@ async fn test_ping_command(#[future] client: MusicPlayerClient) {
     let ctx = tarpc::context::current();
     let command = Command::Ping;
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -156,8 +162,14 @@ async fn test_stop_command(#[future] client: MusicPlayerClient) {
     let ctx = tarpc::context::current();
     let command = Command::Stop;
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -215,8 +227,14 @@ async fn test_library_command(
     let ctx = tarpc::context::current();
     let command = Command::Library { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -228,8 +246,14 @@ async fn test_status_command(#[future] client: MusicPlayerClient, #[case] comman
     let ctx = tarpc::context::current();
     let command = Command::Status { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -238,8 +262,14 @@ async fn test_state_command(#[future] client: MusicPlayerClient) {
     let ctx = tarpc::context::current();
     let command = Command::State;
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -251,8 +281,14 @@ async fn test_current_command(#[future] client: MusicPlayerClient, #[case] targe
     let ctx = tarpc::context::current();
     let command = Command::Current { target };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -264,8 +300,14 @@ async fn test_rand_command(#[future] client: MusicPlayerClient, #[case] target: 
     let ctx = tarpc::context::current();
     let command = Command::Rand { target };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -282,8 +324,14 @@ async fn test_search_command(#[future] client: MusicPlayerClient, #[case] target
         limit: 10,
     };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -314,8 +362,14 @@ async fn test_playback_command(
     let ctx = tarpc::context::current();
     let command = Command::Playback { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -333,8 +387,14 @@ async fn test_queue_command(#[future] client: MusicPlayerClient, #[case] command
     let ctx = tarpc::context::current();
     let command = Command::Queue { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -354,8 +414,14 @@ async fn test_playlist_command(
     let ctx = tarpc::context::current();
     let command = Command::Playlist { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -371,8 +437,14 @@ async fn test_collection_command(
     let ctx = tarpc::context::current();
     let command = Command::Collection { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }
 
 #[rstest]
@@ -385,6 +457,12 @@ async fn test_radio_command(#[future] client: MusicPlayerClient, #[case] command
     let ctx = tarpc::context::current();
     let command = Command::Radio { command };
 
-    let result = command.handle(ctx, client.await).await;
+    let stdout = &mut WriteAdapter(Vec::new());
+    let stderr = &mut WriteAdapter(Vec::new());
+
+    let result = command.handle(ctx, client.await, stdout, stderr).await;
     assert!(result.is_ok());
+
+    insta::assert_snapshot!(String::from_utf8(stdout.0.clone()).unwrap());
+    insta::assert_snapshot!(String::from_utf8(stderr.0.clone()).unwrap());
 }

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: Get { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: Get { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: List }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stderr-Collection { command: Recluster }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: Get { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: Get { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(Collection { id: Thing { tb: "collection", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, name: "Collection 0", runtime: 180s, song_count: 1 })

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: List }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Collections:
+	collection:01J1K5B6RJ84WJXCWYJ5WNE12E: "Collection 0" (1 songs, 180s)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_command@stdout-Collection { command: Recluster }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok("reclustering started")

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_freeze@stderr-Collection { command: Freeze { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", name: "Test Collection" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__collection_freeze@stderr-Collection { command: Freeze { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", name: "Test Collection" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Album }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Album }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Artist }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Artist }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Song }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stderr-Current { target: Song }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Album }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Album }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+None

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Artist }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Artist }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+None

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Song }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__current_command@stdout-Current { target: Song }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+None

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Analyze }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Analyze }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Brief }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Brief }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Full }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Full }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Get { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Health }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Health }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Albums } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Albums } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Artists } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Artists } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Songs } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: false, target: Songs } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Albums } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Albums } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Artists } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Artists } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Songs } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: List { full: true, target: Songs } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Recluster }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Rescan }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stderr-Library { command: Rescan }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Analyze }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Analyze }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Library analysis started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Brief }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Brief }.snap
@@ -1,0 +1,14 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok(
+    LibraryBrief {
+        artists: 1,
+        albums: 1,
+        songs: 1,
+        playlists: 1,
+        collections: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Full }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Full }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok(LibraryFull { artists: [Artist { id: Thing { tb: "artist", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, name: "Test Artist", runtime: 180s, album_count: 1, song_count: 1 }], albums: [Album { id: Thing { tb: "album", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, title: "Test Album", artist: One("Test Artist"), release: Some(2021), runtime: 180s, song_count: 1, discs: 1, genre: One("Test Genre") }], songs: [Song { id: Thing { tb: "song", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, title: "Test Song", artist: One("Test Artist"), album_artist: One("Test Artist"), album: "Test Album", genre: One("Test Genre"), runtime: 180s, track: Some(0), disc: Some(0), release_year: Some(2021), extension: "mp3", path: "test.mp3" }], playlists: [Playlist { id: Thing { tb: "playlist", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, name: "Test Playlist", runtime: 180s, song_count: 1 }], collections: [Collection { id: Thing { tb: "collection", id: String("01J1K5B6RJ84WJXCWYJ5WNE12E") }, name: "Collection 0", runtime: 180s, song_count: 1 }] })

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,28 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Album {
+        id: Thing {
+            tb: "album",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        title: "Test Album",
+        artist: One(
+            "Test Artist",
+        ),
+        release: Some(
+            2021,
+        ),
+        runtime: 180s,
+        song_count: 1,
+        discs: 1,
+        genre: One(
+            "Test Genre",
+        ),
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,19 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Artist {
+        id: Thing {
+            tb: "artist",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        name: "Test Artist",
+        runtime: 180s,
+        album_count: 1,
+        song_count: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,18 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Playlist {
+        id: Thing {
+            tb: "playlist",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        name: "Test Playlist",
+        runtime: 180s,
+        song_count: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Get { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,38 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Song {
+        id: Thing {
+            tb: "song",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        title: "Test Song",
+        artist: One(
+            "Test Artist",
+        ),
+        album_artist: One(
+            "Test Artist",
+        ),
+        album: "Test Album",
+        genre: One(
+            "Test Genre",
+        ),
+        runtime: 180s,
+        track: Some(
+            0,
+        ),
+        disc: Some(
+            0,
+        ),
+        release_year: Some(
+            2021,
+        ),
+        extension: "mp3",
+        path: "test.mp3",
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Health }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Health }.snap
@@ -1,0 +1,21 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok(
+    LibraryHealth {
+        artists: 1,
+        albums: 1,
+        songs: 1,
+        unanalyzed_songs: Some(
+            0,
+        ),
+        playlists: 1,
+        collections: 1,
+        orphaned_artists: 0,
+        orphaned_albums: 0,
+        orphaned_playlists: 0,
+        orphaned_collections: 0,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Albums } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Albums } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Albums:
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist")),

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Artists } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Artists } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Artists:
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Songs } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: false, target: Songs } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Songs:
+	"Test Song" (id: song:01J1K5B6RJ84WJXCWYJ5WNE12E),

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Albums } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Albums } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Albums:
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist")),

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Artists } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Artists } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Artists:
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Songs } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: List { full: true, target: Songs } }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Songs:
+	song:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Song"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Recluster }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+reclustering started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Rescan }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__library_command@stdout-Library { command: Rescan }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Library rescan started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__ping_command@stderr-Ping.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__ping_command@stderr-Ping.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__ping_command@stdout-Ping.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__ping_command@stdout-Ping.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+pong

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Next }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Next }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Pause }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Pause }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Play }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Play }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Previous }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Previous }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: Continuous } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: Continuous } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: None } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: None } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: Once } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Repeat { mode: Once } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Restart }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Restart }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Shuffle }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Shuffle }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Stop }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Stop }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Toggle }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Toggle }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Decrease { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Decrease { amount: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Increase { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Increase { amount: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Mute } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Mute } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Set { volume: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Set { volume: 0.0 } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Unmute } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stderr-Playback { command: Volume { command: Unmute } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Next }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Next }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+next track started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Pause }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Pause }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playback paused

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Play }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Play }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playback started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Previous }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Previous }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+previous track started

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: Continuous } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: Continuous } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+repeat mode set to Continuous

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: None } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: None } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+repeat mode set to None

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: Once } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Repeat { mode: Once } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+repeat mode set to Once

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Restart }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Restart }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playback restarted

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
@@ -3,4 +3,4 @@ source: cli/src/handlers/smoke_tests.rs
 expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
-seeked to position 0.00s
+sought to position 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Absolute { position: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+seeked to position 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+seeked backward by 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Backward { amount: 0.0 } } }.snap
@@ -3,4 +3,4 @@ source: cli/src/handlers/smoke_tests.rs
 expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
-seeked backward by 0.00s
+sought backward by 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
@@ -3,4 +3,4 @@ source: cli/src/handlers/smoke_tests.rs
 expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
-seeked forward by 0.00s
+sought forward by 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Seek { command: Forward { amount: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+seeked forward by 0.00s

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Shuffle }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Shuffle }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+queue shuffled

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Stop }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Stop }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playback stopped

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Toggle }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Toggle }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playback toggled

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Decrease { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Decrease { amount: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+volume decreased by 0

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Increase { amount: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Increase { amount: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+volume increased by 0

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Mute } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Mute } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+volume muted

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Set { volume: 0.0 } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Set { volume: 0.0 } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+volume set to 0

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Unmute } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playback_command@stdout-Playback { command: Volume { command: Unmute } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+volume unmuted

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", album_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", album_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", artist_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", artist_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", song_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Add { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", song_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Delete { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Delete { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Get { method: Id, target: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Get { method: Id, target: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Get { method: Name, target: "Test Playlist" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Get { method: Name, target: "Test Playlist" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: List }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Remove { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", item_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stderr-Playlist { command: Remove { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", item_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", album_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", album_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Err(Database("SurrealDB error: Serialization error: missing field `name`"))

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", artist_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", artist_id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok("artist added to playlist")

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", song_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Add { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", song_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Ok("songs added to playlist")

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Delete { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Delete { id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playlist deleted

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Get { method: Id, target: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Get { method: Id, target: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,18 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Playlist {
+        id: Thing {
+            tb: "playlist",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        name: "Test Playlist",
+        runtime: 180s,
+        song_count: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Get { method: Name, target: "Test Playlist" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Get { method: Name, target: "Test Playlist" } }.snap
@@ -1,0 +1,18 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Playlist {
+        id: Thing {
+            tb: "playlist",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        name: "Test Playlist",
+        runtime: 180s,
+        song_count: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: List }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Playlists:
+	playlist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Playlist" (1 songs, 180s)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Remove { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", item_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__playlist_command@stdout-Playlist { command: Remove { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", item_ids: ["01J1K5B6RJ84WJXCWYJ5WNE12E"] } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+songs removed from playlist

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Collection, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Collection, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Add { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Clear }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Clear }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: List }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Remove { start: 0, end: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Remove { start: 0, end: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Set { index: 0 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stderr-Queue { command: Set { index: 0 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Album, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+album added to queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Artist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+artist added to queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Collection, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Collection, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+collection added to queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Playlist, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+playlist added to queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Add { target: Song, id: "01J1K5B6RJ84WJXCWYJ5WNE12E" } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+song added to queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Clear }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Clear }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+queue cleared

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: List }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: List }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Queue:

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Remove { start: 0, end: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Remove { start: 0, end: 1 } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+items removed from queue

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Set { index: 0 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__queue_command@stdout-Queue { command: Set { index: 0 } }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+current song set to index 0

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Playlist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Playlist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stderr-Radio { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Album { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Artist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Playlist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Playlist { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__radio_command@stdout-Radio { command: Song { id: "01J1K5B6RJ84WJXCWYJ5WNE12E", n: 1 } }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Album }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Album }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Artist }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Artist }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Song }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stderr-Rand { target: Song }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Album }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Album }.snap
@@ -1,0 +1,28 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Album {
+        id: Thing {
+            tb: "album",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        title: "Test Album",
+        artist: One(
+            "Test Artist",
+        ),
+        release: Some(
+            2021,
+        ),
+        runtime: 180s,
+        song_count: 1,
+        discs: 1,
+        genre: One(
+            "Test Genre",
+        ),
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Artist }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Artist }.snap
@@ -1,0 +1,19 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Artist {
+        id: Thing {
+            tb: "artist",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        name: "Test Artist",
+        runtime: 180s,
+        album_count: 1,
+        song_count: 1,
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Song }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__rand_command@stdout-Rand { target: Song }.snap
@@ -1,0 +1,38 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Some(
+    Song {
+        id: Thing {
+            tb: "song",
+            id: String(
+                "01J1K5B6RJ84WJXCWYJ5WNE12E",
+            ),
+        },
+        title: "Test Song",
+        artist: One(
+            "Test Artist",
+        ),
+        album_artist: One(
+            "Test Artist",
+        ),
+        album: "Test Album",
+        genre: One(
+            "Test Genre",
+        ),
+        runtime: 180s,
+        track: Some(
+            0,
+        ),
+        disc: Some(
+            0,
+        ),
+        release_year: Some(
+            2021,
+        ),
+        extension: "mp3",
+        path: "test.mp3",
+    },
+)

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Album, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Album, query: "test", limit: 10 }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: All, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: All, query: "test", limit: 10 }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Artist, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Artist, query: "test", limit: 10 }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Song, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stderr-Search { target: Song, query: "test", limit: 10 }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Album, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Album, query: "test", limit: 10 }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Albums:
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist")),

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: All, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: All, query: "test", limit: 10 }.snap
@@ -1,0 +1,13 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Songs:
+	song:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Song"
+
+Albums:
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist")),
+
+Artists:
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Artist, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Artist, query: "test", limit: 10 }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Artists:
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Song, query: "test", limit: 10 }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__search_command@stdout-Search { target: Song, query: "test", limit: 10 }.snap
@@ -1,0 +1,7 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+Songs:
+	song:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Song"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__state_command@stderr-State.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__state_command@stderr-State.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__state_command@stdout-State.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__state_command@stdout-State.snap
@@ -1,0 +1,13 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+StateAudio:
+	Queue: [
+
+	],
+	Queue Position: None,
+	Repeat Mode: None
+	Paused: true
+	Muted: false
+	Volume: 100.00%

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Analyze }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Analyze }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Recluster }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Rescan }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stderr-Status { command: Rescan }.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Analyze }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Analyze }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+there is not an analysis in progress

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Recluster }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Recluster }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+there is not a reclustering in progress

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Rescan }.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__status_command@stdout-Status { command: Rescan }.snap
@@ -1,0 +1,6 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon response:
+there is not a rescan in progress

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__stop_command@stderr-Stop.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__stop_command@stderr-Stop.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stderr.0.clone()).unwrap()"
+---
+

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__stop_command@stdout-Stop.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__stop_command@stdout-Stop.snap
@@ -1,0 +1,5 @@
+---
+source: cli/src/handlers/smoke_tests.rs
+expression: "String::from_utf8(stdout.0.clone()).unwrap()"
+---
+Daemon stopping, check the daemon logs for more information

--- a/cli/src/handlers/utils.rs
+++ b/cli/src/handlers/utils.rs
@@ -1,3 +1,6 @@
+use core::fmt;
+use std::io;
+
 use mecomp_storage::db::schemas::Thing;
 
 pub fn parse_things_from_lines<Lines>(lines: Lines) -> Vec<Thing>
@@ -10,4 +13,19 @@ where
         }
         acc
     })
+}
+
+pub struct WriteAdapter<W>(pub W);
+
+impl<W> fmt::Write for WriteAdapter<W>
+where
+    W: io::Write,
+{
+    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        self.0.write_all(s.as_bytes()).map_err(|_| fmt::Error)
+    }
+
+    fn write_fmt(&mut self, args: fmt::Arguments) -> Result<(), fmt::Error> {
+        self.0.write_fmt(args).map_err(|_| fmt::Error)
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 mod handlers;
 
-use handlers::CommandHandler;
+use handlers::{utils::WriteAdapter, CommandHandler};
 
 /// Options configurable via the CLI.
 #[derive(Debug, Parser)]
@@ -25,8 +25,13 @@ async fn main() -> anyhow::Result<()> {
 
     let ctx = tarpc::context::current();
 
+    let mut stdout_adapter = WriteAdapter(std::io::stdout());
+    let mut stderr_adapter = WriteAdapter(std::io::stderr());
+
     if let Some(command) = flags.subcommand {
-        command.handle(ctx, client).await?;
+        command
+            .handle(ctx, client, &mut stdout_adapter, &mut stderr_adapter)
+            .await?;
     } else {
         eprintln!("No subcommand provided");
     }


### PR DESCRIPTION
Rewrote the CLI smoke tests as snapshot tests so that instead of just checking if the commands don't fail, it also ensures that their output is what's expected

fixes #199 