### PR TITLE
feat(core/udp): improved performance and scalability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,12 +2869,14 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "ciborium",
+ "criterion",
  "directories",
  "env_logger",
  "lofty",
  "log",
  "mecomp-storage",
  "mecomp-workspace-hack",
+ "object-pool",
  "once_cell",
  "one-or-many",
  "opentelemetry 0.27.1",
@@ -3422,6 +3424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object-pool"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceffa2e6ccecd71e60a0f06b655df2c66acd1c0c892dafefc96fd49d65f71d53"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ notify-debouncer-full = { version = "0.5.0", default-features = false }
 notify = { version = "8.0", default-features = false, features = [
     "macos_fsevent",
 ] }
+object-pool = "0.6.0"
 once_cell = "1.19"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rodio = { version = "0.20.1", features = ["symphonia-all"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["audio"]
+default = ["audio", "rpc"]
 rpc = ["dep:tarpc", "dep:ciborium", "dep:tokio"]
 otel_tracing = [
     "dep:tracing-opentelemetry",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,9 +12,13 @@ license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+name = "udp"
+harness = false
+
 [features]
 default = ["audio", "rpc"]
-rpc = ["dep:tarpc", "dep:ciborium", "dep:tokio"]
+rpc = ["dep:tarpc", "dep:ciborium", "dep:tokio", "dep:object-pool"]
 otel_tracing = [
     "dep:tracing-opentelemetry",
     "dep:opentelemetry",
@@ -46,6 +50,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-flame = { workspace = true, optional = true }
+object-pool = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -58,6 +63,7 @@ mecomp-workspace-hack = { version = "0.1", path = "../mecomp-workspace-hack" }
 
 [dev-dependencies]
 # shared dev dependencies
+criterion.workspace = true
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }

--- a/core/benches/udp.rs
+++ b/core/benches/udp.rs
@@ -1,0 +1,591 @@
+//! Currently, the daemon needs to hold an Arc<Mutex<Sender>> to send messages to clients, the reason the mutex is necessary
+//! is because the sender's `.send` method takes a mutable reference to self (needed since senders hold their own buffers and we need to write to the buffer before sending).
+//! A question I have is whether the overhead of having the mutex and having to clear the buffer before every send is worth not having to allocate a new buffer for every send.
+//!
+//! This file contains benchmarks to compare the performance of the UDP sender with the performance of a new buffer for every send, with varying numbers of: subscribers, server threads, message sizes, and message frequencies/concurrency.
+//!
+//! # Results
+//!
+//! Note, the two benchmarks that are currently unused were used to find that performance was not affected in any interesting way by the size of the messages or the number of subscribers.
+//!
+//! ## When threads send a constant number of total messages (e.g., 8 messages per thread if 8 threads and 64 total messages)
+//!
+//! ### Mutex
+//!
+//! unaffected by the number of threads
+//!
+//! ### RwLock
+//!
+//! performance scales linearly with the number of threads
+//!
+//! ### Insights
+//!
+//! - The RwLock implementation is able to take advantage of additional threads to improve performance, while the Mutex cannot.
+//!
+//! ## When threads send a constant number of messages per thread (e.g., 64 messages per thread if 8 threads)
+//!
+//! ### Mutex
+//!
+//! throughput is unaffected by the number of threads
+//!
+//! ### RwLock
+//!
+//! throughput scales linearly with the number of threads
+//!
+//! ### Insights
+//!
+//! - Again, the RwLock implementation is able to take advantage of additional threads to improve performance, while the Mutex cannot.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use criterion::{criterion_group, criterion_main, Criterion};
+use object_pool::Pool;
+use tokio::net::UdpSocket;
+use tokio::runtime::Runtime;
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinSet;
+
+#[derive(Debug)]
+pub struct MockListener<const BUF_SIZE: usize> {
+    socket: UdpSocket,
+    buffer: [u8; BUF_SIZE],
+}
+
+impl<const B: usize> MockListener<B> {
+    /// Create a new UDP listener bound to the given socket address.
+    /// With a custom buffer size (set with const generics).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket cannot be bound.
+    pub async fn with_buffer_size() -> Result<Self> {
+        let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await?;
+
+        Ok(Self {
+            socket,
+            buffer: [0; B],
+        })
+    }
+
+    /// Get the socket address of the listener
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket address cannot be retrieved.
+    pub fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(self.socket.local_addr()?)
+    }
+
+    /// Receive a message from the UDP socket.
+    pub async fn recv(&mut self) -> Result<(usize, SocketAddr), std::io::Error> {
+        self.socket.recv_from(&mut self.buffer).await
+    }
+}
+
+pub struct MockSender {
+    socket: UdpSocket,
+    buffer: Vec<u8>,
+    buffer_pool: Pool<Vec<u8>>,
+    /// List of subscribers to send messages to
+    subscribers: Vec<SocketAddr>,
+}
+
+impl MockSender {
+    /// Create a new UDP sender bound to an ephemeral port.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket cannot be bound or connected.
+    pub async fn new(message_size: usize) -> Result<Self> {
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+
+        Ok(Self {
+            socket,
+            buffer: Vec::with_capacity(message_size),
+            buffer_pool: Pool::new(16, || Vec::with_capacity(message_size)),
+            subscribers: Vec::new(),
+        })
+    }
+
+    /// Add a subscriber to the list of subscribers.
+    pub fn add_subscriber(&mut self, subscriber: SocketAddr) {
+        self.subscribers.push(subscriber);
+    }
+
+    /// Send a message to the UDP socket.
+    /// Cancel safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be serialized or sent.
+    pub async fn send(&mut self, message: &[u8]) -> Result<()> {
+        self.buffer.clear();
+
+        self.buffer.extend_from_slice(message);
+
+        for subscriber in &self.subscribers {
+            self.socket.send_to(&self.buffer, subscriber).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Send a message to the UDP socket.
+    /// Cancel safe.
+    ///
+    /// creates a new buffer every time
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be serialized or sent.
+    pub async fn send_with_temporary_buffer<const B: usize>(&self, message: &[u8]) -> Result<()> {
+        let mut buffer = Vec::with_capacity(B);
+        buffer.extend_from_slice(message);
+
+        for subscriber in &self.subscribers {
+            self.socket.send_to(&buffer, subscriber).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Send a message to the UDP socket using a buffer pool.
+    /// Cancel safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be serialized or sent.
+    pub async fn send_with_buffer_pool(&self, message: &[u8]) -> Result<()> {
+        let mut buffer = self.buffer_pool.pull(|| Vec::with_capacity(message.len()));
+        buffer.clear();
+
+        // write to the buffer
+        buffer.extend_from_slice(message);
+
+        for subscriber in &self.subscribers {
+            self.socket
+                .send_to(&buffer[..message.len()], subscriber)
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn _bench_mutex(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // the sizes of messages, in bytes, to test
+    let message_sizes = vec![1, 10, 100];
+
+    // The number of subscribers to send messages to in each test
+    let subscriber_counts = vec![2, 4];
+
+    // The number of "server threads" sending messages concurrently
+    let server_thread_counts = vec![1, 2, 4, 8];
+
+    // The number of messages to send in each test
+    const MESSAGE_COUNT: usize = 64;
+
+    let mut group = c.benchmark_group("udp_sender_mutex");
+    group.warm_up_time(Duration::from_secs(1));
+
+    for message_size in &message_sizes {
+        for subscriber_count in &subscriber_counts {
+            // create a sender with the given message size
+            let sender = Arc::new(Mutex::new(
+                rt.block_on(MockSender::new(*message_size)).unwrap(),
+            ));
+
+            // create the listeners
+            let mut listeners = Vec::with_capacity(*subscriber_count);
+
+            for _ in 0..*subscriber_count {
+                let listener = rt
+                    .block_on(MockListener::<1024>::with_buffer_size())
+                    .unwrap();
+                rt.block_on(sender.lock())
+                    .add_subscriber(listener.local_addr().unwrap());
+                listeners.push(listener);
+            }
+
+            for server_thread_count in &server_thread_counts {
+                group.throughput(criterion::Throughput::Elements(
+                    (MESSAGE_COUNT * *server_thread_count * *subscriber_count) as u64,
+                ));
+                // benchmark the sender
+                group.bench_with_input(
+                    format!(
+                        "message_size_{message_size}_subscribers_{subscriber_count}_server_threads_{server_thread_count}",
+                    )
+                    .as_str(),
+                    &(*message_size, *server_thread_count),
+                    |b, &(message_size, server_thread_count)| {
+                        b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                            || {
+                                (
+                                    sender.clone(),
+                                    (0..message_size)
+                                        .map(|_| rand::random::<u8>())
+                                        .collect::<Vec<u8>>(),
+                                )
+                            },
+                            |(sender, message)| async move {
+                                let mut handles = JoinSet::new();
+
+                                for _ in 0..server_thread_count {
+                                    let sender = sender.clone();
+                                    let message = message.clone();
+                                    handles.spawn(async move {
+                                        for _ in 0..MESSAGE_COUNT  {
+                                            sender.lock().await.send(&message).await.unwrap();
+                                        }
+                                    });
+                                }
+
+                                handles.join_all().await;
+                            },
+                        );
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+fn _bench_rwlock(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // the sizes of messages, in bytes, to test
+    let message_sizes = vec![1, 10, 100];
+
+    // The number of subscribers to send messages to in each test
+    let subscriber_counts = vec![2, 4];
+
+    // The number of "server threads" sending messages concurrently
+    let server_thread_counts = vec![1, 2, 4, 8];
+
+    // The number of messages to send in each test
+    const MESSAGE_COUNT: usize = 64;
+
+    let mut group = c.benchmark_group("udp_sender_rwlock");
+    group.warm_up_time(Duration::from_secs(1));
+
+    for message_size in &message_sizes {
+        for subscriber_count in &subscriber_counts {
+            // create a sender with the given message size
+            let sender = Arc::new(RwLock::new(
+                rt.block_on(MockSender::new(*message_size)).unwrap(),
+            ));
+
+            // create the listeners
+            let mut listeners = Vec::with_capacity(*subscriber_count);
+
+            for _ in 0..*subscriber_count {
+                let listener = rt
+                    .block_on(MockListener::<1024>::with_buffer_size())
+                    .unwrap();
+                rt.block_on(sender.write())
+                    .add_subscriber(listener.local_addr().unwrap());
+                listeners.push(listener);
+            }
+
+            for server_thread_count in &server_thread_counts {
+                group.throughput(criterion::Throughput::Elements(
+                    (MESSAGE_COUNT * *server_thread_count * *subscriber_count) as u64,
+                ));
+                // benchmark the sender
+                group.bench_with_input(
+                    format!(
+                        "message_size_{message_size}_subscribers_{subscriber_count}_server_threads_{server_thread_count}",
+                    )
+                    .as_str(),
+                    &(*message_size, *server_thread_count),
+                    |b, &(message_size, server_thread_count)| {
+                        b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                            || {
+                                (
+                                    sender.clone(),
+                                    (0..message_size)
+                                        .map(|_| rand::random::<u8>())
+                                        .collect::<Vec<u8>>(),
+                                )
+                            },
+                            |(sender, message)| async move {
+                                let mut handles = JoinSet::new();
+
+                                for _ in 0..server_thread_count {
+                                    let sender = sender.clone();
+                                    let message = message.clone();
+                                    handles.spawn(async move {
+                                        for _ in 0..MESSAGE_COUNT  {
+                                            sender.read().await.send_with_temporary_buffer::<1024>(&message).await.unwrap();
+                                        }
+                                    });
+                                }
+
+                                handles.join_all().await;
+                            },
+                        );
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmark designed to compare the runtime performance of using a Mutex vs RwLock for the UDP sender.
+///
+/// does this by splitting the messages to send evenly among the threads
+fn bench_performance(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // the sizes of messages, in bytes, to test
+    const MESSAGE_SIZE: usize = 10;
+
+    // The number of subscribers to send messages to in each test
+    const SUBSCRIBER_COUNT: usize = 3;
+
+    // The number of "server threads" sending messages concurrently
+    let server_thread_counts = vec![1, 2, 4, 8, 16];
+
+    // The number of messages to send in each test
+    const MESSAGE_COUNT: usize = 64;
+
+    let mut group = c.benchmark_group("mutex vs rwlock performance");
+
+    // create a sender with the given message size
+    let mut mutex_sender = rt.block_on(MockSender::new(MESSAGE_SIZE)).unwrap();
+    let mut rwlock_sender = rt.block_on(MockSender::new(MESSAGE_SIZE)).unwrap();
+
+    // create the listeners
+    let mut listeners = Vec::with_capacity(SUBSCRIBER_COUNT);
+
+    for _ in 0..SUBSCRIBER_COUNT {
+        let listener = rt
+            .block_on(MockListener::<1024>::with_buffer_size())
+            .unwrap();
+        mutex_sender.add_subscriber(listener.local_addr().unwrap());
+        rwlock_sender.add_subscriber(listener.local_addr().unwrap());
+        listeners.push(listener);
+    }
+
+    let mutex_sender = Arc::new(Mutex::new(mutex_sender));
+    let rwlock_sender = Arc::new(RwLock::new(rwlock_sender));
+
+    for server_thread_count in &server_thread_counts {
+        // benchmark the sender with a mutex
+        group.throughput(criterion::Throughput::Bytes(
+            (MESSAGE_SIZE * MESSAGE_COUNT * SUBSCRIBER_COUNT) as u64,
+        ));
+        group.bench_with_input(
+            format!("mutex__server_threads_{server_thread_count:02}"),
+            server_thread_count,
+            |b, &server_thread_count| {
+                b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                    || {
+                        (
+                            mutex_sender.clone(),
+                            (0..MESSAGE_SIZE)
+                                .map(|_| rand::random::<u8>())
+                                .collect::<Vec<u8>>(),
+                        )
+                    },
+                    |(sender, message)| async move {
+                        let mut handles = JoinSet::new();
+
+                        for _ in 0..server_thread_count {
+                            let sender = sender.clone();
+                            let message = message.clone();
+                            handles.spawn(async move {
+                                for _ in 0..MESSAGE_COUNT / server_thread_count {
+                                    sender.lock().await.send(&message).await.unwrap();
+                                }
+                            });
+                        }
+
+                        handles.join_all().await;
+                    },
+                );
+            },
+        );
+
+        // benchmark the sender with a rwlock
+        group.throughput(criterion::Throughput::Bytes(
+            (MESSAGE_SIZE * MESSAGE_COUNT * SUBSCRIBER_COUNT) as u64,
+        ));
+        group.bench_with_input(
+            format!("rwlock__server_threads_{server_thread_count:02}"),
+            server_thread_count,
+            |b, &server_thread_count| {
+                b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                    || {
+                        (
+                            rwlock_sender.clone(),
+                            (0..MESSAGE_SIZE)
+                                .map(|_| rand::random::<u8>())
+                                .collect::<Vec<u8>>(),
+                        )
+                    },
+                    |(sender, message)| async move {
+                        let mut handles = JoinSet::new();
+
+                        for _ in 0..server_thread_count {
+                            let sender = sender.clone();
+                            let message = message.clone();
+                            handles.spawn(async move {
+                                for _ in 0..MESSAGE_COUNT / server_thread_count {
+                                    sender
+                                        .read()
+                                        .await
+                                        .send_with_buffer_pool(&message)
+                                        .await
+                                        .unwrap();
+                                }
+                            });
+                        }
+
+                        handles.join_all().await;
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark designed to compare the throughput performance of using a Mutex vs RwLock for the UDP sender.
+///
+/// does this by giving each thread 64 messages to send, regardless of the number of threads
+fn bench_throughput(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // the sizes of messages, in bytes, to test
+    const MESSAGE_SIZE: usize = 10;
+
+    // The number of subscribers to send messages to in each test
+    const SUBSCRIBER_COUNT: usize = 3;
+
+    // The number of "server threads" sending messages concurrently
+    let server_thread_counts = vec![1, 2, 4, 8, 16];
+
+    // The number of messages to send in each test
+    const MESSAGE_COUNT: usize = 64;
+
+    let mut group = c.benchmark_group("mutex vs rwlock throughput");
+
+    // create a sender with the given message size
+    let mut mutex_sender = rt.block_on(MockSender::new(MESSAGE_SIZE)).unwrap();
+    let mut rwlock_sender = rt.block_on(MockSender::new(MESSAGE_SIZE)).unwrap();
+
+    // create the listeners
+    let mut listeners = Vec::with_capacity(SUBSCRIBER_COUNT);
+
+    for _ in 0..SUBSCRIBER_COUNT {
+        let listener = rt
+            .block_on(MockListener::<1024>::with_buffer_size())
+            .unwrap();
+        mutex_sender.add_subscriber(listener.local_addr().unwrap());
+        rwlock_sender.add_subscriber(listener.local_addr().unwrap());
+        listeners.push(listener);
+    }
+
+    let mutex_sender = Arc::new(Mutex::new(mutex_sender));
+    let rwlock_sender = Arc::new(RwLock::new(rwlock_sender));
+
+    for server_thread_count in &server_thread_counts {
+        // benchmark the sender with a mutex
+        group.throughput(criterion::Throughput::Bytes(
+            (MESSAGE_SIZE * MESSAGE_COUNT * SUBSCRIBER_COUNT * *server_thread_count) as u64,
+        ));
+        group.bench_with_input(
+            format!("mutex__server_threads_{server_thread_count:02}"),
+            server_thread_count,
+            |b, &server_thread_count| {
+                b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                    || {
+                        (
+                            mutex_sender.clone(),
+                            (0..MESSAGE_SIZE)
+                                .map(|_| rand::random::<u8>())
+                                .collect::<Vec<u8>>(),
+                        )
+                    },
+                    |(sender, message)| async move {
+                        let mut handles = JoinSet::new();
+
+                        for _ in 0..server_thread_count {
+                            let sender = sender.clone();
+                            let message = message.clone();
+                            handles.spawn(async move {
+                                for _ in 0..MESSAGE_COUNT {
+                                    sender.lock().await.send(&message).await.unwrap();
+                                }
+                            });
+                        }
+
+                        handles.join_all().await;
+                    },
+                );
+            },
+        );
+
+        // benchmark the sender with a rwlock
+        group.throughput(criterion::Throughput::Bytes(
+            (MESSAGE_SIZE * MESSAGE_COUNT * SUBSCRIBER_COUNT * *server_thread_count) as u64,
+        ));
+        group.bench_with_input(
+            format!("rwlock__server_threads_{server_thread_count:02}"),
+            server_thread_count,
+            |b, &server_thread_count| {
+                b.to_async(Runtime::new().unwrap()).iter_with_setup(
+                    || {
+                        (
+                            rwlock_sender.clone(),
+                            (0..MESSAGE_SIZE)
+                                .map(|_| rand::random::<u8>())
+                                .collect::<Vec<u8>>(),
+                        )
+                    },
+                    |(sender, message)| async move {
+                        let mut handles = JoinSet::new();
+
+                        for _ in 0..server_thread_count {
+                            let sender = sender.clone();
+                            let message = message.clone();
+                            handles.spawn(async move {
+                                for _ in 0..MESSAGE_COUNT {
+                                    sender
+                                        .read()
+                                        .await
+                                        .send_with_buffer_pool(&message)
+                                        .await
+                                        .unwrap();
+                                }
+                            });
+                        }
+
+                        handles.join_all().await;
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_plots();
+    targets = bench_throughput, bench_performance
+);
+criterion_main!(benches);

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// An error in the UDP stack.
 #[derive(Error, Debug)]
+#[cfg(feature = "rpc")]
 pub enum UdpError {
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
@@ -33,6 +34,7 @@ pub enum LibraryError {
     #[cfg(feature = "audio")]
     Decoder(#[from] rodio::decoder::DecoderError),
     #[error("UdpError: {0}")]
+    #[cfg(feature = "rpc")]
     Udp(#[from] UdpError),
 }
 
@@ -51,6 +53,7 @@ pub enum SerializableLibraryError {
     #[error("Collection Reclustering already in progress.")]
     ReclusterInProgress,
     #[error("UdpError: {0}")]
+    #[cfg(feature = "rpc")]
     Udp(String),
 }
 
@@ -73,6 +76,7 @@ impl From<rodio::decoder::DecoderError> for SerializableLibraryError {
     }
 }
 
+#[cfg(feature = "rpc")]
 impl From<UdpError> for SerializableLibraryError {
     fn from(e: UdpError) -> Self {
         Self::Udp(e.to_string())
@@ -86,6 +90,7 @@ impl From<LibraryError> for SerializableLibraryError {
             LibraryError::IO(e) => Self::IO(e.to_string()),
             #[cfg(feature = "audio")]
             LibraryError::Decoder(e) => Self::Decoder(e.to_string()),
+            #[cfg(feature = "rpc")]
             LibraryError::Udp(e) => Self::Udp(e.to_string()),
         }
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -58,8 +58,8 @@ impl SearchResult {
 /// The music player service, implemented by the music player daemon.
 #[tarpc::service]
 pub trait MusicPlayer {
-    /// Get the UDP address that the daemon publishes events to
-    async fn get_udp_addr() -> Result<SocketAddr, SerializableLibraryError>;
+    /// Register a UDP listener with the daemon.
+    async fn register_listener(listener_addr: SocketAddr) -> ();
 
     // misc
     async fn ping() -> String;

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -20,7 +20,7 @@ use mecomp_core::{
         library::{LibraryBrief, LibraryFull, LibraryHealth},
         RepeatMode, SeekType, StateAudio,
     },
-    udp::{Event, Sender},
+    udp::{Event, Message, Sender},
 };
 use mecomp_storage::{
     db::schemas::{
@@ -48,7 +48,7 @@ pub struct MusicPlayerServer {
     library_rescan_lock: Arc<Mutex<()>>,
     library_analyze_lock: Arc<Mutex<()>>,
     collection_recluster_lock: Arc<Mutex<()>>,
-    publisher: Arc<Mutex<Sender>>,
+    publisher: Arc<Mutex<Sender<Message>>>,
 }
 
 impl MusicPlayerServer {
@@ -57,7 +57,7 @@ impl MusicPlayerServer {
         db: Arc<Surreal<Db>>,
         settings: Arc<Settings>,
         audio_kernel: Arc<AudioKernelSender>,
-        event_publisher: Sender,
+        event_publisher: Sender<Message>,
     ) -> Self {
         Self {
             db,

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -73,11 +73,8 @@ impl MusicPlayerServer {
 
 impl MusicPlayer for MusicPlayerServer {
     #[instrument]
-    async fn get_udp_addr(
-        self,
-        context: Context,
-    ) -> Result<std::net::SocketAddr, SerializableLibraryError> {
-        Ok(self.publisher.lock().await.peer_addr()?)
+    async fn register_listener(self, context: Context, listener_addr: std::net::SocketAddr) {
+        self.publisher.lock().await.add_subscriber(listener_addr);
     }
 
     #[instrument]

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn start_daemon(
 
     // Start the audio kernel.
     let audio_kernel = AudioKernelSender::start();
-    let event_publisher = Sender::new(settings.daemon.rpc_port).await?;
+    let event_publisher = Sender::new().await?;
     let server = MusicPlayerServer::new(
         db.clone(),
         settings.clone(),
@@ -141,7 +141,7 @@ pub async fn init_test_client_server(
 ) -> anyhow::Result<MusicPlayerClient> {
     let (client_transport, server_transport) = tarpc::transport::channel::unbounded();
 
-    let event_publisher = Sender::new(settings.daemon.rpc_port).await?;
+    let event_publisher = Sender::new().await?;
     let server = MusicPlayerServer::new(db, settings, audio_kernel, event_publisher);
     tokio::spawn(
         tarpc::server::BaseChannel::with_defaults(server_transport)

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -31,8 +31,10 @@ impl Subscriber {
         action_tx: mpsc::UnboundedSender<Action>,
         mut interrupt_rx: broadcast::Receiver<Interrupted>,
     ) -> anyhow::Result<Interrupted> {
-        let socket_addr = daemon.get_udp_addr(Context::current()).await??;
-        let mut listener = Listener::new(socket_addr).await?;
+        let mut listener = Listener::new().await?;
+        daemon
+            .register_listener(Context::current(), listener.local_addr()?)
+            .await?;
 
         #[allow(clippy::redundant_pub_crate)]
         let result = loop {


### PR DESCRIPTION
Good Practices:
Instead of broadcasting to the whole network over UDP (which is bad because it can lead to unnecessary network congestion at scale), only send events to registered clients. We don't need a way to deregister clients, since UDP is a connectionless protocol and doesn't care whether packets reach their destination.

Performance wins motivated by benchmarks:
Switched the UDP `Sender`'s buffer to a buffer pool to enable `Sender::send` to take an immutable reference to `self`, this allowed me to switch `MusicPlayerServer.publisher` from `Arc<Mutex<Sender>>` to `Arc<RwLock<Sender>>` which allows the Daemon to take advantage of available parallelism when publishing events.

Misc:
rewrote `Listener` and `Sender` to be generic over the datatype they receive/send.

