### PR TITLE
fix(storage): fix panic on defining analyzer

### DIFF
--- a/storage/src/db/mod.rs
+++ b/storage/src/db/mod.rs
@@ -71,7 +71,6 @@ pub async fn init_database() -> surrealdb::Result<Surreal<Db>> {
 }
 
 #[cfg(feature = "db")]
-#[allow(clippy::missing_inline_in_public_items)]
 pub(crate) async fn register_custom_analyzer<C>(db: &Surreal<C>) -> surrealdb::Result<()>
 where
     C: surrealdb::Connection,
@@ -86,7 +85,7 @@ where
             "ascii",
             "lowercase",
             "edgengram(1, 10)",
-            "snowball(english)",
+            "snowball(English)",
         ],
     ))
     .await?;


### PR DESCRIPTION
for some reason, the define_analyzer function would fail but only when running a daemon binary installed through cargo install, this should fix that though