### PR TITLE
fix(tests): fix flaky test

### DIFF
--- a/storage/src/db/mod.rs
+++ b/storage/src/db/mod.rs
@@ -262,7 +262,7 @@ mod minimal_reproduction {
         let result: Vec<User> = db.delete("users").await.unwrap();
 
         assert_eq!(result.len(), NUMBER_OF_USERS);
-        assert_eq!(result[0], john);
-        assert_eq!(result[1], sally);
+        assert!(result.contains(&john), "Result does not contain 'john'");
+        assert!(result.contains(&sally), "Result does not contain 'sally'");
     }
 }


### PR DESCRIPTION
the test that ensured that our new "counting" query is faster then the old one sometimes fails in CI, making it operate on 100 records instead of 2 should make it more consistent