### PR TITLE
feat(one-or-many): enhance deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,13 +3799,14 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "one-or-many"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "mecomp-workspace-hack",
  "pretty_assertions",
  "rstest",
  "serde",
+ "serde_json",
  "surrealdb",
  "surrealqlx",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ mecomp-storage = { path = "storage", default-features = false, version = "=0.3.1
 surrealqlx = { path = "surrealqlx/lib", version = "=0.1.2" }
 surrealqlx-macros = { path = "surrealqlx/macros", version = "=0.1.2" }
 surrealqlx-macros-impl = { path = "surrealqlx/macros-impl", version = "=0.1.2" }
-one-or-many = { path = "one-or-many", version = "=0.2.0" }
+one-or-many = { path = "one-or-many", version = "=0.3.0", default-features = false }
 
 # shared dev dependencies
 pretty_assertions = "1.4"

--- a/one-or-many/Cargo.toml
+++ b/one-or-many/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "one-or-many"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 description = "Utility container for working with data that can either be null, a single value, or a list of values."
@@ -14,7 +14,7 @@ license.workspace = true
 bench = false
 
 [features]
-default = []
+default = ["serde"]
 serde = ["dep:serde"]
 surrealdb = ["serde", "dep:surrealdb"]
 
@@ -26,6 +26,7 @@ mecomp-workspace-hack = { version = "0.1", path = "../mecomp-workspace-hack" }
 [dev-dependencies]
 rstest = { workspace = true }
 pretty_assertions = { workspace = true }
+serde_json = "1.0"
 surrealqlx = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
implement a custom deserializer so that empty lists, or lists with only one item, get deserialized as OneOrMany::None, or OneOrMany::One, respectively