### PR TITLE
refactor(core): overhaul duration tracking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-lint = "clippy --all --all-features -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery -D clippy::perf"                          # -D clippy::cargo
+lint =     "clippy --all --all-features                      -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery -D clippy::perf" # -D clippy::cargo
 lint-fix = "clippy --all --all-features --fix --allow-staged -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery -D clippy::perf" # -D clippy::cargo
 coverage = "tarpaulin --skip-clean --out Html --workspace --profile tarpaulin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ ndarray-rand.opt-level = 3
 ndarray-stats.opt-level = 3
 statrs.opt-level = 3
 rustfft.opt-level = 3
+# Set audio libraries to optimize for speed in tests
+symphonia.opt-level = 3
+rodio.opt-level = 3
 
 [profile.tarpaulin]
 inherits = "test"

--- a/core/src/audio/mod.rs
+++ b/core/src/audio/mod.rs
@@ -111,7 +111,7 @@ pub(crate) struct AudioKernel {
     /// Channel that the audio kernel might use to send `AudioCommand`'s
     /// to itself over (e.g., in a callback)
     command_tx: Sender<(AudioCommand, tracing::Span)>,
-    /// Channel that the audio kernel recieves `AudioCommand`'s over
+    /// Channel that the audio kernel receives `AudioCommand`'s over
     command_rx: Receiver<(AudioCommand, tracing::Span)>,
     /// Event publisher for when the audio kernel changes state
     event_tx: Sender<StateChange>,

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -1098,6 +1098,8 @@ impl MusicPlayer for MusicPlayerServer {
         id: PlaylistId,
         path: PathBuf,
     ) -> Result<(), SerializableLibraryError> {
+        info!("Exporting playlist to: {}", path.display());
+
         // validate the path
         validate_file_path(&path, "m3u", false)?;
 
@@ -1131,6 +1133,8 @@ impl MusicPlayer for MusicPlayerServer {
         path: PathBuf,
         name: Option<String>,
     ) -> Result<PlaylistId, SerializableLibraryError> {
+        info!("Importing playlist from: {}", path.display());
+
         // validate the path
         validate_file_path(&path, "m3u", true)?;
 
@@ -1381,6 +1385,8 @@ impl MusicPlayer for MusicPlayerServer {
         context: Context,
         path: PathBuf,
     ) -> Result<(), SerializableLibraryError> {
+        info!("Exporting dynamic playlists to: {path:?}");
+
         // validate the path
         validate_file_path(&path, "csv", false)?;
 
@@ -1406,6 +1412,8 @@ impl MusicPlayer for MusicPlayerServer {
         context: Context,
         path: PathBuf,
     ) -> Result<Vec<DynamicPlaylist>, SerializableLibraryError> {
+        info!("Importing dynamic playlists from: {path:?}");
+
         // validate the path
         validate_file_path(&path, "csv", true)?;
 

--- a/daemon/src/dynamic_updates.rs
+++ b/daemon/src/dynamic_updates.rs
@@ -445,7 +445,7 @@ mod tests {
     }
 
     #[rstest]
-    #[timeout(Duration::from_secs(5))]
+    #[timeout(Duration::from_secs(10))]
     #[tokio::test]
     async fn test_rename_song(
         #[future] setup: (TempDir, Arc<Surreal<Db>>, MusicLibEventHandlerGuard),
@@ -505,7 +505,7 @@ mod tests {
     }
 
     #[rstest]
-    #[timeout(Duration::from_secs(5))]
+    #[timeout(Duration::from_secs(10))]
     #[tokio::test]
     async fn test_modify_song(
         #[future] setup: (TempDir, Arc<Surreal<Db>>, MusicLibEventHandlerGuard),
@@ -548,7 +548,7 @@ mod tests {
     }
 
     #[rstest]
-    #[timeout(Duration::from_secs(5))]
+    #[timeout(Duration::from_secs(10))]
     #[tokio::test]
     async fn test_remove_song(
         #[future] setup: (TempDir, Arc<Surreal<Db>>, MusicLibEventHandlerGuard),


### PR DESCRIPTION
overhaul duration tracking,
removing the duration watcher thread entirely,
as well as the `duration_info` field previously used to track the duration of the current song and amount of the song that's been played.

the `current_duration` field of the `DurationInfo` was only ever read by the `state` command, which has access to the `current_song` field anyway so we can just use that.

the `time_played` field of the `DurationInfo` was replaced with calls to `player.get_pos()`, which was introduced in rodio v0.19.0.

One downside of this approach is that now we have a slight gap in playback since we only start the next song when the current song is completely done (as opposed to starting 100ms before it ends, like we used to)