### PR TITLE
feat(daemon): improve gracefull shutdown

### DIFF
--- a/daemon/benches/analyze.rs
+++ b/daemon/benches/analyze.rs
@@ -3,7 +3,7 @@
 use std::num::NonZeroUsize;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use mecomp_daemon::services::library::analyze;
+use mecomp_daemon::{services::library::analyze, termination::InterruptReceiver};
 use mecomp_storage::{
     db::schemas::song::Song,
     test_utils::{arb_song_case, arb_vec, create_song_metadata, init_test_database},
@@ -44,7 +44,9 @@ fn benchmark_analyze(c: &mut Criterion) {
                 .unwrap()
             },
             async |db| {
-                analyze(&db, false).await.unwrap();
+                analyze(&db, InterruptReceiver::dummy(), false)
+                    .await
+                    .unwrap();
             },
         );
     });

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -234,7 +234,12 @@ impl MusicPlayer for MusicPlayerServer {
             tokio::task::spawn(
                 async move {
                     let _guard = self.collection_recluster_lock.lock().await;
-                    match services::library::recluster(&self.db, &self.settings.reclustering).await
+                    match services::library::recluster(
+                        &self.db,
+                        self.settings.reclustering,
+                        self.interrupt.resubscribe(),
+                    )
+                    .await
                     {
                         Ok(()) => info!("Collection reclustering complete"),
                         Err(e) => error!("Error in library_recluster: {e}"),

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -151,6 +151,7 @@ pub async fn start_daemon(
         audio_kernel.clone(),
         event_publisher_guard.dispatcher.clone(),
         terminator.clone(),
+        interrupt_rx.resubscribe(),
     );
 
     // Start the RPC server.
@@ -248,6 +249,7 @@ pub async fn init_test_client_server(
             audio_kernel.clone(),
             event_publisher.clone(),
             terminator,
+            interrupt_rx.resubscribe(),
         );
         tokio::select! {
             () = tarpc::server::BaseChannel::with_defaults(server_transport)
@@ -257,7 +259,7 @@ pub async fn init_test_client_server(
                     tokio::spawn(response);
                 }) => {},
             // Wait for the server to be stopped.
-            _ = interrupt_rx.recv() => {
+            _ = interrupt_rx.wait() => {
                 // Stop the server.
                 info!("Stopping server...");
                 audio_kernel.send(AudioCommand::Exit);

--- a/daemon/src/termination.rs
+++ b/daemon/src/termination.rs
@@ -20,8 +20,6 @@ const FORCE_QUIT_THRESHOLD: u8 = 3;
 /// A struct that handles listening for interrupt signals, and/or tracking whether an interrupt signal has been received.
 ///
 /// Essentially, the receiving side of the broadcast channel.
-///
-/// Usefull to stop processes that we can't terminate otherwise.
 pub struct InterruptReceiver {
     interrupt_rx: broadcast::Receiver<Interrupted>,
     stopped: Arc<AtomicBool>,

--- a/daemon/src/termination.rs
+++ b/daemon/src/termination.rs
@@ -12,6 +12,8 @@ pub enum Interrupted {
     UserInt,
 }
 
+const FORCE_QUIT_THRESHOLD: u8 = 3;
+
 #[derive(Debug)]
 /// Used to handle the termination of the application.
 ///
@@ -129,26 +131,49 @@ async fn terminate_by_signal(terminator: Terminator) {
     let mut quit_signal = signal(tokio::signal::unix::SignalKind::quit())
         .expect("failed to create quit signal stream");
 
-    tokio::select! {
-        _ = interrupt_signal.recv() => {
-            terminator
-                .terminate(Interrupted::OsSigInt)
-                .expect("failed to send interrupt signal");
+    let mut signal_tick = tokio::time::interval(std::time::Duration::from_secs(1));
+    signal_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut kill_count = 0;
+
+    loop {
+        // if we've received 3 signals, we should forcefully terminate the application
+        if kill_count >= FORCE_QUIT_THRESHOLD {
+            log::warn!(
+                "Received {FORCE_QUIT_THRESHOLD} signals, forcefully terminating the application"
+            );
+            std::process::exit(1);
         }
-        _ = term_signal.recv() => {
-            terminator
-                .terminate(Interrupted::OsSigTerm)
-                .expect("failed to send terminate signal");
-        }
-        _ = quit_signal.recv() => {
-            terminator
-                .terminate(Interrupted::OsSigQuit)
-                .expect("failed to send quit signal");
-        }
-        _ = tokio::signal::ctrl_c() => {
-            terminator
-                .terminate(Interrupted::UserInt)
-                .expect("failed to send interrupt signal");
+
+        tokio::select! {
+            _ = signal_tick.tick() => {
+                // If we receive a signal within 1 second, we can ignore it
+                // and wait for the next signal.
+            }
+            _ = interrupt_signal.recv() => {
+                if let Err(e) = terminator.terminate(Interrupted::OsSigInt) {
+                    log::warn!("failed to send interrupt signal: {e}");
+                }
+                kill_count += 1;
+            }
+            _ = term_signal.recv() => {
+                if let Err(e) = terminator.terminate(Interrupted::OsSigTerm) {
+                    log::warn!("failed to send terminate signal: {e}");
+                }
+                kill_count += 1;
+            }
+            _ = quit_signal.recv() => {
+                if let Err(e) = terminator.terminate(Interrupted::OsSigQuit) {
+                    log::warn!("failed to send quit signal: {e}");
+                }
+                kill_count += 1;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                if let Err(e) = terminator.terminate(Interrupted::UserInt) {
+                    log::warn!("failed to send interrupt signal: {e}");
+                }
+                kill_count += 1;
+            }
         }
     }
 }
@@ -157,16 +182,41 @@ async fn terminate_by_signal(terminator: Terminator) {
 async fn terminate_by_signal(mut terminator: Terminator) {
     // On non-unix systems, we don't have any signals to handle.
     // We can still use the ctrl_c signal to terminate the application.
-    tokio::signal::ctrl_c()
-        .await
-        .expect("failed to create ctrl_c signal stream");
 
-    terminator
-        .terminate(Interrupted::UserInt)
-        .expect("failed to send interrupt signal");
+    let mut signal_tick = tokio::time::interval(std::time::Duration::from_secs(1));
+    signal_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut kill_count = 0;
+
+    loop {
+        // if we've received 3 signals, we should forcefully terminate the application
+        if kill_count >= FORCE_QUIT_THRESHOLD {
+            log::warn!(
+                "Received {FORCE_QUIT_THRESHOLD} signals, forcefully terminating the application"
+            );
+            std::process::exit(1);
+        }
+
+        tokio::select! {
+            _ = signal_tick.tick() => {
+                // If we receive a signal within 1 second, we can ignore it
+                // and wait for the next signal.
+            }
+            _ = tokio::signal::ctrl_c() => {
+                if let Err(e) = terminator.terminate(Interrupted::UserInt) {
+                    log::warn!("failed to send interrupt signal: {e}");
+                }
+                kill_count += 1;
+            }
+        }
+    }
 }
 
-// create a broadcast channel for retrieving the application kill signal
+/// create a broadcast channel for retrieving the application kill signal
+///
+/// # Panics
+///
+/// This function will panic if the tokio runtime cannot be created.
 #[allow(clippy::module_name_repetitions)]
 #[must_use]
 #[inline]
@@ -175,8 +225,19 @@ pub fn create_termination() -> (Terminator, InterruptReceiver) {
     let terminator = Terminator::new(tx);
     let interrupt = InterruptReceiver::new(rx);
 
-    #[cfg(unix)]
-    tokio::spawn(terminate_by_signal(terminator.clone()));
+    // runtime for the terminator
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .thread_name("mecomp-terminator")
+        .build()
+        .unwrap();
+    let terminator_clone = terminator.clone();
+
+    std::thread::spawn(move || {
+        rt.block_on(async {
+            terminate_by_signal(terminator_clone).await;
+        });
+    });
 
     (terminator, interrupt)
 }

--- a/daemon/src/termination.rs
+++ b/daemon/src/termination.rs
@@ -37,9 +37,17 @@ impl InterruptReceiver {
 
     #[must_use]
     #[inline]
+    /// Create a dummy receiver that doesn't receive any signals
+    ///
+    /// Attempting to wait on this receiver will wait indefinitely.
     pub fn dummy() -> Self {
+        let (tx, rx) = broadcast::channel(1);
+
+        // forget the sender so it's dropped w/o calling its destructor
+        std::mem::forget(tx);
+
         Self {
-            interrupt_rx: broadcast::channel(1).1,
+            interrupt_rx: rx,
             stopped: Arc::new(AtomicBool::new(false)),
         }
     }

--- a/tui/src/termination.rs
+++ b/tui/src/termination.rs
@@ -68,7 +68,6 @@ pub fn create_termination() -> (Terminator, broadcast::Receiver<Interrupted>) {
     let (tx, rx) = broadcast::channel(1);
     let terminator = Terminator::new(tx);
 
-    #[cfg(unix)]
     tokio::spawn(terminate_by_unix_signal(terminator.clone()));
 
     (terminator, rx)


### PR DESCRIPTION
Previously, the daemon could hang for a bit if it got a shutdown signal while performing an analysis or recluster job.
Now, it can shutdown while analyzing since the shutdown drops the receiver end of the channel the analysis workers send their outputs over. In the past all the remaining songs would be analyzed but fial to sent their output, now it will stop processing new songs after the first failure.
Doing something like this wasn't as easy for reclustering though, so now the termination handler will keep listening for kill signals after the first one and if it gets more than 2 it will force quit the application w/ `std::process:exit(1)`