### PR TITLE
feat(storage): use computed fields in favor of calling repair all the time

### DIFF
--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_playlist_command_case_02@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_playlist_command_case_02@stdout.snap
@@ -3,4 +3,4 @@ source: cli/src/handlers/smoke_tests.rs
 expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
-Err(Database("SurrealDB error: Serialization error: missing field `name`"))
+Ok("album added to playlist")

--- a/core/src/logger.rs
+++ b/core/src/logger.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use std::{io::Write, sync::LazyLock};
 
 use env_logger::fmt::style::{RgbColor, Style};
@@ -259,7 +259,7 @@ pub fn init_tracing() -> impl tracing::Subscriber {
 
     #[cfg(feature = "tokio_console")]
     let console_layer = console_subscriber::Builder::default()
-        .retention(Duration::from_secs(60 * 20)) // 20 minutes
+        .retention(std::time::Duration::from_secs(60 * 20)) // 20 minutes
         .enable_self_trace(true)
         .spawn();
     #[cfg(feature = "tokio_console")]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -63,7 +63,7 @@ tracing = { workspace = true }
 walkdir = { workspace = true }
 
 # MECOMP dependencies
-mecomp-core = { workspace = true, features = ["rpc", "audio", "tokio_console"] }
+mecomp-core = { workspace = true, features = ["rpc", "audio"] }
 mecomp-storage = { workspace = true, features = ["serde", "db"] }
 mecomp-analysis = { workspace = true, optional = true }
 one-or-many = { workspace = true }

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -1137,6 +1137,9 @@ impl MusicPlayer for MusicPlayerServer {
         let (parsed_name, song_paths) =
             import_playlist(file).tap_err(|e| warn!("Error in playlist_import: {e}"))?;
 
+        log::debug!("Parsed playlist name: {parsed_name:?}");
+        log::debug!("Parsed song paths: {song_paths:?}");
+
         let name = match (name, parsed_name) {
             (Some(name), _) | (None, Some(name)) => name,
             (None, None) => "Imported Playlist".to_owned(),

--- a/daemon/src/services/library.rs
+++ b/daemon/src/services/library.rs
@@ -85,7 +85,7 @@ pub async fn rescan<C: Connection>(
                     };
                     info!(
                         "{} has conflicting metadata with index, {log_postfix}",
-                        path.to_string_lossy(),
+                        path.display(),
                     );
 
                     match conflict_resolution_mode {
@@ -103,9 +103,8 @@ pub async fn rescan<C: Connection>(
                 // if we have an error, delete the song from the library
                 Err(e) => {
                     warn!(
-                        "Error reading metadata for {}: {}",
-                        path.to_string_lossy(),
-                        e
+                        "Error reading metadata for {}: {e}",
+                        path.display()
                     );
                     info!("assuming the file isn't a song or doesn't exist anymore, removing from library");
                     Song::delete(db, song.id).await?;
@@ -143,6 +142,8 @@ pub async fn rescan<C: Connection>(
 
             visited_paths.insert(path.path().to_owned());
 
+            let displayable_path = path.path().display();
+
             // if the file is a song, add it to the library
             match SongMetadata::load_from_path(
                 path.path().to_owned(),
@@ -151,14 +152,10 @@ pub async fn rescan<C: Connection>(
                 genre_separator,
             ) {
                 Ok(metadata) => Song::try_load_into_db(db, metadata).await.map_or_else(
-                    |e| warn!("Error indexing {}: {}", path.path().to_string_lossy(), e),
-                    |_| debug!("Indexed {}", path.path().to_string_lossy()),
+                    |e| warn!("Error indexing {displayable_path}: {e}"),
+                    |_| debug!("Indexed {displayable_path}"),
                 ),
-                Err(e) => warn!(
-                    "Error reading metadata for {}: {}",
-                    path.path().to_string_lossy(),
-                    e
-                ),
+                Err(e) => warn!("Error reading metadata for {displayable_path}: {e}"),
             }
         }
 
@@ -168,7 +165,6 @@ pub async fn rescan<C: Connection>(
     .await?;
 
     // find and delete any remaining orphaned albums and artists
-    // TODO: create a custom query for this
 
     async {
         for album in Album::read_all(db).await? {
@@ -181,17 +177,13 @@ pub async fn rescan<C: Connection>(
     }
     .instrument(tracing::info_span!("Repairing albums"))
     .await?;
-    async {
-        for artist in Artist::read_all(db).await? {
-            if Artist::repair(db, artist.id.clone()).await? {
-                info!("Deleted orphaned artist {}", artist.id.clone());
-                Artist::delete(db, artist.id.clone()).await?;
-            }
-        }
-        <Result<(), Error>>::Ok(())
+
+    let orphans = Artist::delete_orphaned(db)
+        .instrument(tracing::info_span!("Repairing artists"))
+        .await?;
+    if !orphans.is_empty() {
+        info!("Deleted orphaned artists: {orphans:?}");
     }
-    .instrument(tracing::info_span!("Repairing artists"))
-    .await?;
 
     let orphans = Collection::delete_orphaned(db)
         .instrument(tracing::info_span!("Repairing collections"))
@@ -739,6 +731,11 @@ mod tests {
         // check that the album and artist deleted
         assert_eq!(Song::read_all(&db).await.unwrap().len(), 0);
         assert_eq!(Album::read_all(&db).await.unwrap().len(), 0);
+        let artists = Artist::read_all(&db).await.unwrap();
+        for artist in artists {
+            assert_eq!(artist.album_count, 0);
+            assert_eq!(artist.song_count, 0);
+        }
         assert_eq!(Artist::read_all(&db).await.unwrap().len(), 0);
     }
 

--- a/storage/src/db/crud/song.rs
+++ b/storage/src/db/crud/song.rs
@@ -180,7 +180,8 @@ impl Song {
 
             // remove song from the old album, if it existed
             if let Some(old_album) = old_album {
-                if Album::remove_songs(db, old_album.id.clone(), vec![id.clone()]).await? {
+                Album::remove_songs(db, old_album.id.clone(), vec![id.clone()]).await?;
+                if old_album.song_count <= 1 {
                     // if the album is left without any songs, delete it
                     info!("Deleting orphaned album: {:?}", old_album.id);
                     Album::delete(db, old_album.id).await?;
@@ -257,7 +258,8 @@ impl Song {
             Collection::remove_songs(db, collection.id.clone(), vec![id.clone()]).await?;
         }
         if let Some(album) = Self::read_album(db, id.clone()).await? {
-            if Album::remove_songs(db, album.id.clone(), vec![id.clone()]).await? {
+            Album::remove_songs(db, album.id.clone(), vec![id.clone()]).await?;
+            if album.song_count <= 1 {
                 info!("Deleting orphaned album: {:?}", album.id);
                 Album::delete(db, album.id).await?;
             }

--- a/storage/src/db/crud/song.rs
+++ b/storage/src/db/crud/song.rs
@@ -252,10 +252,7 @@ impl Song {
             Playlist::remove_songs(db, playlist.id, vec![id.clone()]).await?;
         }
         for collection in Self::read_collections(db, id.clone()).await? {
-            if Collection::remove_songs(db, collection.id.clone(), vec![id.clone()]).await? {
-                info!("Deleting orphaned collection: {:?}", collection.id);
-                Collection::delete(db, collection.id).await?;
-            }
+            Collection::remove_songs(db, collection.id.clone(), vec![id.clone()]).await?;
         }
         if let Some(album) = Self::read_album(db, id.clone()).await? {
             if Album::remove_songs(db, album.id.clone(), vec![id.clone()]).await? {

--- a/storage/src/db/crud/song.rs
+++ b/storage/src/db/crud/song.rs
@@ -189,7 +189,8 @@ impl Song {
 
             // remove the album from the old album artist(s)
             for artist in Self::read_album_artist(db, id.clone()).await? {
-                if Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await? {
+                Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await?;
+                if artist.song_count <= 1 {
                     // if the artist is left without any songs, delete it
                     info!("Deleting orphaned artist: {:?}", artist.id);
                     Artist::delete(db, artist.id).await?;
@@ -207,7 +208,8 @@ impl Song {
 
             // remove song from the old artists
             for artist in old_artist {
-                if Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await? {
+                Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await?;
+                if artist.song_count <= 1 {
                     // if the artist is left without any songs, delete it
                     info!("Deleting orphaned artist: {:?}", artist.id);
                     Artist::delete(db, artist.id).await?;
@@ -261,13 +263,16 @@ impl Song {
             }
         }
         for artist in Self::read_album_artist(db, id.clone()).await? {
-            if Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await? {
+            Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await?;
+            if artist.song_count <= 1 {
                 info!("Deleting orphaned artist: {:?}", artist.id);
                 Artist::delete(db, artist.id).await?;
             }
         }
         for artist in Self::read_artist(db, id.clone()).await? {
-            if Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await? {
+            Artist::remove_songs(db, artist.id.clone(), vec![id.clone()]).await?;
+            if artist.song_count <= 1 {
+                // if I'm the only song, delete the artist
                 info!("Deleting orphaned artist: {:?}", artist.id);
                 Artist::delete(db, artist.id).await?;
             }

--- a/storage/src/db/mod.rs
+++ b/storage/src/db/mod.rs
@@ -54,7 +54,10 @@ pub async fn init_database() -> surrealdb::Result<Surreal<Db>> {
     });
     let db = Surreal::new((db_path, config)).await?;
 
-    db.use_ns("mecomp").use_db("music").await?;
+    db.query("DEFINE NAMESPACE IF NOT EXISTS mecomp").await?;
+    db.use_ns("mecomp").await?;
+    db.query("DEFINE DATABASE IF NOT EXISTS music").await?;
+    db.use_db("music").await?;
 
     register_custom_analyzer(&db).await?;
     surrealqlx::register_tables!(
@@ -110,9 +113,14 @@ mod test {
 
     #[tokio::test]
     async fn test_register_tables() -> anyhow::Result<()> {
+        let config = Config::new().strict();
         // use an in-memory db for testing
-        let db = Surreal::new::<Mem>(()).await?;
-        db.use_ns("test").use_db("test").await?;
+        let db = Surreal::new::<Mem>(config).await?;
+
+        db.query("DEFINE NAMESPACE IF NOT EXISTS test").await?;
+        db.use_ns("test").await?;
+        db.query("DEFINE DATABASE IF NOT EXISTS test").await?;
+        db.use_db("test").await?;
 
         // register the custom analyzer
         register_custom_analyzer(&db).await?;

--- a/storage/src/db/schemas/playlist.rs
+++ b/storage/src/db/schemas/playlist.rs
@@ -25,7 +25,13 @@ pub struct Playlist {
     pub name: String,
 
     /// Total runtime.
-    #[cfg_attr(feature = "db", field(dt = "duration"))]
+    #[cfg_attr(
+        feature = "db",
+        field(dt = "any VALUE <future> {
+LET $songs = (SELECT runtime FROM $this.id->playlist_to_song->song);
+RETURN IF $songs IS NONE { 0s } ELSE { $songs.fold(0s, |$acc, $song| $acc + $song.runtime) };
+} ")
+    )]
     #[cfg_attr(
         feature = "db",
         serde(
@@ -36,7 +42,13 @@ pub struct Playlist {
     pub runtime: Duration,
 
     /// the number of songs this playlist has.
-    #[cfg_attr(feature = "db", field(dt = "int"))]
+    #[cfg_attr(
+        feature = "db",
+        field(dt = "any VALUE <future> { 
+LET $count = (SELECT count() FROM $this.id->playlist_to_song->song GROUP ALL);
+RETURN IF $count IS NONE { 0 } ELSE IF $count.len() == 0 { 0 } ELSE { ($count[0]).count };
+} ")
+    )]
     pub song_count: usize,
 }
 
@@ -53,14 +65,6 @@ impl Playlist {
 pub struct PlaylistChangeSet {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    #[cfg_attr(
-        feature = "db",
-        serde(serialize_with = "super::serialize_duration_option_as_sql_duration")
-    )]
-    pub runtime: Option<Duration>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub song_count: Option<usize>,
 }
 
 impl PlaylistChangeSet {
@@ -74,20 +78,6 @@ impl PlaylistChangeSet {
     #[inline]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
-        self
-    }
-
-    #[must_use]
-    #[inline]
-    pub const fn runtime(mut self, runtime: Duration) -> Self {
-        self.runtime = Some(runtime);
-        self
-    }
-
-    #[must_use]
-    #[inline]
-    pub const fn song_count(mut self, song_count: usize) -> Self {
-        self.song_count = Some(song_count);
         self
     }
 }

--- a/storage/src/db/schemas/song.rs
+++ b/storage/src/db/schemas/song.rs
@@ -280,6 +280,9 @@ impl SongMetadata {
         if !path.exists() || !path.is_file() {
             return Err(SongIOError::FileNotFound(path));
         }
+        // attempt to canonicalize the path
+        let path = path.canonicalize()?;
+
         // get metadata from the file
         let tagged_file = Probe::open(&path)
             .map_err(SongIOError::LoftyError)?


### PR DESCRIPTION
closes #308 

I'd like to make better use of SurrealDB's features for things like automatically deleting orphaned items as well, but that's a task for future me.

This does cause a major (breaking) change to the DB schema though so v0.4.0 will be coming soon!

Somewhere along the line, I also fixed #301