### PR TITLE
refactor(backup): change file existence check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@
 - [ ] allow users to create "smart playlists" that are automatically updated based on a set of criteria (e.g. "all songs with a play count greater than 10", "all songs by Green Day", "all songs with a similarity to Foo greater than X", etc.)
   - [x] these criteria should be able to be combined with set/boolean logic (union (AND), intersection (OR), difference (NOT))
   - [x] criteria can be scoped to allow for more complex queries
-- [ ] allow user to import/export playlists in a standard format (e.g. m3u, xspf, etc.)
+- [x] allow user to import/export playlists in a standard format (e.g. m3u, xspf, etc.)
 
 ### Radio (song suggestions)
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -28,8 +28,6 @@ pub enum DirectoryError {
 /// Errors that can occur when importing or exporting playlists or dynamic playlists
 #[derive(Error, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum BackupError {
-    #[error("The file \"{0}\" already exists")]
-    FileExists(PathBuf),
     #[error("The file \"{0}\" does not exist")]
     FileNotFound(PathBuf),
     #[error("The file \"{0}\" has the wrong extension, expected: {1}")]

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1085,15 +1085,7 @@ Dynamic Playlist 0,"artist CONTAINS ""Artist 0"""
         let response = client
             .dynamic_playlist_export(ctx, tmpfile.path().to_path_buf())
             .await?;
-        assert!(
-            matches!(
-                response,
-                Err(SerializableLibraryError::BackupError(
-                    BackupError::FileExists(_)
-                ))
-            ),
-            "response: {response:?}"
-        );
+        assert!(matches!(response, Ok(())), "response: {response:?}");
         Ok(())
     }
     #[rstest]

--- a/daemon/src/services/backup.rs
+++ b/daemon/src/services/backup.rs
@@ -20,8 +20,10 @@ use csv::{Reader, Writer};
 /// # Arguments
 ///
 /// * `path` - The path to validate
-/// * `exists` - Whether the file should exist or not
 /// * `extension` - The expected file extension
+/// * `exists` - Whether the file should exist or not
+///   * if true, the file must exist
+///   * if false, the file may not exist but will be overwritten if it does
 pub(crate) fn validate_file_path(
     path: &PathBuf,
     extension: &str,
@@ -39,9 +41,6 @@ pub(crate) fn validate_file_path(
     } else if exists && !path.exists() {
         log::warn!("Path does not exist: {path:?}");
         Err(BackupError::FileNotFound(path.clone()))
-    } else if !exists && path.exists() {
-        log::warn!("Path already exists: {path:?}");
-        Err(BackupError::FileExists(path.clone()))
     } else {
         Ok(())
     }


### PR DESCRIPTION
Made it so that the export commands will just overwrite the export file if it already exists, instead of failing w/ an error