### PR TITLE
feat(rpc): use usize instead of i64 for search limit

### DIFF
--- a/cli/src/handlers/mod.rs
+++ b/cli/src/handlers/mod.rs
@@ -73,7 +73,7 @@ pub enum Command {
 
         /// The maximum number of results to return
         #[clap(default_value = "10", value_hint = ValueHint::Other)]
-        limit: u32,
+        limit: usize,
     },
     /// Playback control
     Playback {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -153,13 +153,13 @@ pub trait MusicPlayer {
 
     // Search (fuzzy keys)
     /// returns a list of artists, albums, and songs matching the given search query.
-    async fn search(query: String, limit: u32) -> SearchResult;
+    async fn search(query: String, limit: usize) -> SearchResult;
     /// returns a list of artists matching the given search query.
-    async fn search_artist(query: String, limit: u32) -> Box<[Artist]>;
+    async fn search_artist(query: String, limit: usize) -> Box<[Artist]>;
     /// returns a list of albums matching the given search query.
-    async fn search_album(query: String, limit: u32) -> Box<[Album]>;
+    async fn search_album(query: String, limit: usize) -> Box<[Album]>;
     /// returns a list of songs matching the given search query.
-    async fn search_song(query: String, limit: u32) -> Box<[Song]>;
+    async fn search_song(query: String, limit: usize) -> Box<[Song]>;
 
     // Playback control.
     /// toggles playback (play/pause).

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -634,26 +634,26 @@ impl MusicPlayer for MusicPlayerServer {
 
     /// returns a list of artists, albums, and songs matching the given search query.
     #[instrument]
-    async fn search(self, context: Context, query: String, limit: u32) -> SearchResult {
+    async fn search(self, context: Context, query: String, limit: usize) -> SearchResult {
         info!("Searching for: {query}");
         // basic idea:
         // 1. search for songs
         // 2. search for albums
         // 3. search for artists
         // 4. return the results
-        let songs = Song::search(&self.db, &query, i64::from(limit))
+        let songs = Song::search(&self.db, &query, limit)
             .await
             .tap_err(|e| warn!("Error in search: {e}"))
             .unwrap_or_default()
             .into();
 
-        let albums = Album::search(&self.db, &query, i64::from(limit))
+        let albums = Album::search(&self.db, &query, limit)
             .await
             .tap_err(|e| warn!("Error in search: {e}"))
             .unwrap_or_default()
             .into();
 
-        let artists = Artist::search(&self.db, &query, i64::from(limit))
+        let artists = Artist::search(&self.db, &query, limit)
             .await
             .tap_err(|e| warn!("Error in search: {e}"))
             .unwrap_or_default()
@@ -666,9 +666,9 @@ impl MusicPlayer for MusicPlayerServer {
     }
     /// returns a list of artists matching the given search query.
     #[instrument]
-    async fn search_artist(self, context: Context, query: String, limit: u32) -> Box<[Artist]> {
+    async fn search_artist(self, context: Context, query: String, limit: usize) -> Box<[Artist]> {
         info!("Searching for artist: {query}");
-        Artist::search(&self.db, &query, i64::from(limit))
+        Artist::search(&self.db, &query, limit)
             .await
             .tap_err(|e| {
                 warn!("Error in search_artist: {e}");
@@ -678,9 +678,9 @@ impl MusicPlayer for MusicPlayerServer {
     }
     /// returns a list of albums matching the given search query.
     #[instrument]
-    async fn search_album(self, context: Context, query: String, limit: u32) -> Box<[Album]> {
+    async fn search_album(self, context: Context, query: String, limit: usize) -> Box<[Album]> {
         info!("Searching for album: {query}");
-        Album::search(&self.db, &query, i64::from(limit))
+        Album::search(&self.db, &query, limit)
             .await
             .tap_err(|e| {
                 warn!("Error in search_album: {e}");
@@ -690,9 +690,9 @@ impl MusicPlayer for MusicPlayerServer {
     }
     /// returns a list of songs matching the given search query.
     #[instrument]
-    async fn search_song(self, context: Context, query: String, limit: u32) -> Box<[Song]> {
+    async fn search_song(self, context: Context, query: String, limit: usize) -> Box<[Song]> {
         info!("Searching for song: {query}");
-        Song::search(&self.db, &query, i64::from(limit))
+        Song::search(&self.db, &query, limit)
             .await
             .tap_err(|e| {
                 warn!("Error in search_song: {e}");

--- a/storage/src/db/crud/album.rs
+++ b/storage/src/db/crud/album.rs
@@ -64,7 +64,7 @@ impl Album {
     pub async fn search<C: Connection>(
         db: &Surreal<C>,
         query: &str,
-        limit: i64,
+        limit: usize,
     ) -> StorageResult<Vec<Self>> {
         Ok(db
             .query("SELECT *, search::score(0) * 2 + search::score(1) * 1 AS relevance FROM album WHERE title @0@ $query OR artist @1@ $query ORDER BY relevance DESC LIMIT $limit")

--- a/storage/src/db/crud/artist.rs
+++ b/storage/src/db/crud/artist.rs
@@ -127,7 +127,7 @@ impl Artist {
     pub async fn search<C: Connection>(
         db: &Surreal<C>,
         query: &str,
-        limit: i64,
+        limit: usize,
     ) -> StorageResult<Vec<Self>> {
         Ok(db
             .query(full_text_search(TABLE_NAME, "name", limit))

--- a/storage/src/db/crud/song.rs
+++ b/storage/src/db/crud/song.rs
@@ -130,7 +130,7 @@ impl Song {
     pub async fn search<C: Connection>(
         db: &Surreal<C>,
         query: &str,
-        limit: i64,
+        limit: usize,
     ) -> StorageResult<Vec<Self>> {
         Ok(db
             .query("SELECT *, search::score(0) * 2 + search::score(1) * 1 AS relevance FROM song WHERE title @0@ $query OR artist @1@ $query ORDER BY relevance DESC LIMIT $limit")

--- a/storage/src/db/queries/generic.rs
+++ b/storage/src/db/queries/generic.rs
@@ -341,9 +341,13 @@ pub fn count_orphaned_both<Table: AsRef<str>, Rel1: AsRef<str>, Rel2: AsRef<str>
 pub fn full_text_search<Table: AsRef<str>, Field: AsRef<str>>(
     table: Table,
     field: Field,
-    limit: i64,
+    limit: usize,
 ) -> impl IntoQuery {
-    fn full_text_search_statement(table: &str, field: &str, limit: i64) -> impl IntoQuery + use<> {
+    fn full_text_search_statement(
+        table: &str,
+        field: &str,
+        limit: usize,
+    ) -> impl IntoQuery + use<> {
         parse_query(format!(
             "SELECT * FROM {table} WHERE {field} @@ ${field} ORDER BY relevance DESC LIMIT {limit}"
         ))


### PR DESCRIPTION
I honestly have no idea why it was an i64, limit should always be positive so usize is the natural choice