### PR TITLE
feat: refactor state management to use LibraryBrief instead of LibraryFull in many places

### DIFF
--- a/cli/src/handlers/complete.rs
+++ b/cli/src/handlers/complete.rs
@@ -102,10 +102,7 @@ fn get_album_candidates(
         .map(|album| {
             (
                 album.id.key().to_string(),
-                StyledStr::from(format!(
-                    "\"{}\" (by: {:?}, {} songs)",
-                    album.title, album.artist, album.song_count
-                )),
+                StyledStr::from(format!("\"{}\" (by: {:?})", album.title, album.artist)),
             )
         })
         .collect()
@@ -128,10 +125,7 @@ fn get_artist_candidates(
         .map(|artist| {
             (
                 artist.id.key().to_string(),
-                StyledStr::from(format!(
-                    "\"{}\" ({} albums, {} songs)",
-                    artist.name, artist.albums, artist.songs
-                )),
+                StyledStr::from(format!("\"{}\"", artist.name)),
             )
         })
         .collect()
@@ -142,22 +136,19 @@ fn get_playlist_candidates(
     client: &MusicPlayerClient,
     ctx: tarpc::context::Context,
 ) -> Vec<(String, StyledStr)> {
-    let response = rt.block_on(client.playlist_list(ctx));
+    let response = rt.block_on(client.library_playlists_brief(ctx));
     if let Err(e) = response {
         eprintln!("Failed to fetch playlists: {e}");
         return vec![];
     }
-    let playlists = response.unwrap();
+    let playlists = response.unwrap().unwrap_or_default();
 
     playlists
         .into_iter()
         .map(|playlist| {
             (
                 playlist.id.key().to_string(),
-                StyledStr::from(format!(
-                    "\"{}\" ({} songs, {:?})",
-                    playlist.name, playlist.songs, playlist.runtime
-                )),
+                StyledStr::from(format!("\"{}\"", playlist.name)),
             )
         })
         .collect()
@@ -195,22 +186,19 @@ fn get_collection_candidates(
     client: &MusicPlayerClient,
     ctx: tarpc::context::Context,
 ) -> Vec<(String, StyledStr)> {
-    let response = rt.block_on(client.collection_list(ctx));
+    let response = rt.block_on(client.library_collections_brief(ctx));
     if let Err(e) = response {
         eprintln!("Failed to fetch collections: {e}");
         return vec![];
     }
-    let collections = response.unwrap();
+    let collections = response.unwrap().unwrap_or_default();
 
     collections
         .into_iter()
         .map(|collection| {
             (
                 collection.id.key().to_string(),
-                StyledStr::from(format!(
-                    "\"{}\" ({} songs, {:?})",
-                    collection.name, collection.songs, collection.runtime
-                )),
+                StyledStr::from(format!("\"{}\"", collection.name)),
             )
         })
         .collect()

--- a/cli/src/handlers/implementations.rs
+++ b/cli/src/handlers/implementations.rs
@@ -85,15 +85,15 @@ impl CommandHandler for Command {
             Self::Rand { target } => {
                 match target {
                     RandTarget::Artist => {
-                        let resp: Option<Artist> = client.rand_artist(ctx).await?;
+                        let resp: Option<ArtistBrief> = client.rand_artist(ctx).await?;
                         writeln!(stdout, "Daemon response:\n{resp:#?}")?;
                     }
                     RandTarget::Album => {
-                        let resp: Option<Album> = client.rand_album(ctx).await?;
+                        let resp: Option<AlbumBrief> = client.rand_album(ctx).await?;
                         writeln!(stdout, "Daemon response:\n{resp:#?}")?;
                     }
                     RandTarget::Song => {
-                        let resp: Option<Song> = client.rand_song(ctx).await?;
+                        let resp: Option<SongBrief> = client.rand_song(ctx).await?;
                         writeln!(stdout, "Daemon response:\n{resp:#?}")?;
                     }
                 }

--- a/cli/src/handlers/printing.rs
+++ b/cli/src/handlers/printing.rs
@@ -5,12 +5,12 @@ use std::fmt::Write;
 use mecomp_core::state::StateAudio;
 use mecomp_storage::db::schemas::{
     RecordId,
-    album::Album,
-    artist::Artist,
-    collection::CollectionBrief,
+    album::AlbumBrief,
+    artist::ArtistBrief,
+    collection::Collection,
     dynamic::{DynamicPlaylist, query::Compile},
-    playlist::PlaylistBrief,
-    song::Song,
+    playlist::Playlist,
+    song::SongBrief,
 };
 
 pub fn audio_state(state: &StateAudio) -> Result<String, std::fmt::Error> {
@@ -69,7 +69,7 @@ pub fn audio_state(state: &StateAudio) -> Result<String, std::fmt::Error> {
     Ok(output)
 }
 
-pub fn indexed_song_list(prefix: &str, songs: &[Song]) -> Result<String, std::fmt::Error> {
+pub fn indexed_song_list(prefix: &str, songs: &[SongBrief]) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
 
     writeln!(output, "{prefix}:")?;
@@ -81,7 +81,11 @@ pub fn indexed_song_list(prefix: &str, songs: &[Song]) -> Result<String, std::fm
     Ok(output)
 }
 
-pub fn song_list(prefix: &str, songs: &[Song], quiet: bool) -> Result<String, std::fmt::Error> {
+pub fn song_list(
+    prefix: &str,
+    songs: &[SongBrief],
+    quiet: bool,
+) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
 
     writeln!(output, "{prefix}:")?;
@@ -103,7 +107,11 @@ pub fn song_list(prefix: &str, songs: &[Song], quiet: bool) -> Result<String, st
     Ok(output)
 }
 
-pub fn album_list(prefix: &str, albums: &[Album], quiet: bool) -> Result<String, std::fmt::Error> {
+pub fn album_list(
+    prefix: &str,
+    albums: &[AlbumBrief],
+    quiet: bool,
+) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
 
     writeln!(output, "{prefix}:")?;
@@ -116,8 +124,8 @@ pub fn album_list(prefix: &str, albums: &[Album], quiet: bool) -> Result<String,
         for album in albums {
             writeln!(
                 output,
-                "\t{}: \"{}\" (by: {:?}, {} songs)",
-                album.id, album.title, album.artist, album.song_count
+                "\t{}: \"{}\" (by: {:?})",
+                album.id, album.title, album.artist
             )?;
         }
     }
@@ -127,7 +135,7 @@ pub fn album_list(prefix: &str, albums: &[Album], quiet: bool) -> Result<String,
 
 pub fn artist_list(
     prefix: &str,
-    artists: &[Artist],
+    artists: &[ArtistBrief],
     quiet: bool,
 ) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
@@ -140,21 +148,14 @@ pub fn artist_list(
         }
     } else {
         for artist in artists {
-            writeln!(
-                output,
-                "\t{}: \"{}\" ({} albums, {} songs)",
-                artist.id, artist.name, artist.album_count, artist.song_count
-            )?;
+            writeln!(output, "\t{}: \"{}\"", artist.id, artist.name)?;
         }
     }
 
     Ok(output)
 }
 
-pub fn playlist_brief_list(
-    prefix: &str,
-    playlists: &[PlaylistBrief],
-) -> Result<String, std::fmt::Error> {
+pub fn playlist_list(prefix: &str, playlists: &[Playlist]) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
 
     writeln!(output, "{prefix}:")?;
@@ -163,7 +164,7 @@ pub fn playlist_brief_list(
         writeln!(
             output,
             "\t{}: \"{}\" ({} songs, {:?})",
-            playlist.id, playlist.name, playlist.songs, playlist.runtime
+            playlist.id, playlist.name, playlist.song_count, playlist.runtime
         )?;
     }
 
@@ -193,7 +194,7 @@ pub fn dynamic_playlist_list(
 
 pub fn collection_list(
     prefix: &str,
-    collections: &[CollectionBrief],
+    collections: &[Collection],
 ) -> Result<String, std::fmt::Error> {
     let mut output = String::new();
 
@@ -203,7 +204,7 @@ pub fn collection_list(
         writeln!(
             output,
             "\t{}: \"{}\" ({} songs, {:?})",
-            collection.id, collection.name, collection.songs, collection.runtime
+            collection.id, collection.name, collection.song_count, collection.runtime
         )?;
     }
 

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_06@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_06@stdout.snap
@@ -5,11 +5,116 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 Daemon response:
 Ok(
     LibraryBrief {
-        artists: 1,
-        albums: 1,
-        songs: 1,
-        playlists: 1,
-        collections: 1,
-        dynamic_playlists: 1,
+        artists: [
+            ArtistBrief {
+                id: Thing {
+                    tb: "artist",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                name: "Test Artist",
+            },
+        ],
+        albums: [
+            AlbumBrief {
+                id: Thing {
+                    tb: "album",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                title: "Test Album",
+                artist: One(
+                    "Test Artist",
+                ),
+                release: Some(
+                    2021,
+                ),
+                discs: 1,
+                genre: One(
+                    "Test Genre",
+                ),
+            },
+        ],
+        songs: [
+            SongBrief {
+                id: Thing {
+                    tb: "song",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                title: "Test Song",
+                artist: One(
+                    "Test Artist",
+                ),
+                album_artist: One(
+                    "Test Artist",
+                ),
+                album: "Test Album",
+                genre: One(
+                    "Test Genre",
+                ),
+                runtime: 180s,
+                track: Some(
+                    0,
+                ),
+                disc: Some(
+                    0,
+                ),
+                release_year: Some(
+                    2021,
+                ),
+                extension: "mp3",
+                path: "test.mp3",
+            },
+        ],
+        playlists: [
+            PlaylistBrief {
+                id: Thing {
+                    tb: "playlist",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                name: "Test Playlist",
+            },
+        ],
+        collections: [
+            CollectionBrief {
+                id: Thing {
+                    tb: "collection",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                name: "Collection 0",
+            },
+        ],
+        dynamic_playlists: [
+            DynamicPlaylist {
+                id: Thing {
+                    tb: "dynamic",
+                    id: String(
+                        "01J1K5B6RJ84WJXCWYJ5WNE12E",
+                    ),
+                },
+                name: "Test Dynamic",
+                query: Query {
+                    root: Leaf(
+                        LeafClause {
+                            left: Field(
+                                Title,
+                            ),
+                            operator: Equal,
+                            right: String(
+                                "Test Song",
+                            ),
+                        },
+                    ),
+                },
+            },
+        ],
     },
 )

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_08@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_08@stdout.snap
@@ -4,4 +4,4 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Artists:
-	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist" (1 albums, 1 songs)
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_10@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_library_command_case_10@stdout.snap
@@ -4,4 +4,4 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Albums:
-	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"), 1 songs)
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"))

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_1@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_1@stdout.snap
@@ -4,7 +4,7 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Some(
-    Album {
+    AlbumBrief {
         id: Thing {
             tb: "album",
             id: String(
@@ -18,8 +18,6 @@ Some(
         release: Some(
             2021,
         ),
-        runtime: 180s,
-        song_count: 1,
         discs: 1,
         genre: One(
             "Test Genre",

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_2@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_2@stdout.snap
@@ -4,7 +4,7 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Some(
-    Artist {
+    ArtistBrief {
         id: Thing {
             tb: "artist",
             id: String(
@@ -12,8 +12,5 @@ Some(
             ),
         },
         name: "Test Artist",
-        runtime: 180s,
-        album_count: 1,
-        song_count: 1,
     },
 )

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_3@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_rand_command_case_3@stdout.snap
@@ -4,7 +4,7 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Some(
-    Song {
+    SongBrief {
         id: Thing {
             tb: "song",
             id: String(

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_1_quiet_2_false@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_1_quiet_2_false@stdout.snap
@@ -4,4 +4,4 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Albums:
-	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"), 1 songs)
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"))

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_2_quiet_2_false@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_2_quiet_2_false@stdout.snap
@@ -4,4 +4,4 @@ expression: "String::from_utf8(stdout.0.clone()).unwrap()"
 ---
 Daemon response:
 Artists:
-	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist" (1 albums, 1 songs)
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_4_quiet_2_false@stdout.snap
+++ b/cli/src/handlers/snapshots/mecomp_cli__handlers__smoke_tests__handlers_smoke_tests_test_search_command_case_4_quiet_2_false@stdout.snap
@@ -7,7 +7,7 @@ Songs:
 	song:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Song" (by: One("Test Artist"), album: Test Album)
 
 Albums:
-	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"), 1 songs)
+	album:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Album" (by: One("Test Artist"))
 
 Artists:
-	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist" (1 albums, 1 songs)
+	artist:01J1K5B6RJ84WJXCWYJ5WNE12E: "Test Artist"

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -39,9 +39,9 @@ pub type DynamicPlaylistId = RecordId;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct SearchResult {
-    pub songs: Box<[Song]>,
-    pub albums: Box<[Album]>,
-    pub artists: Box<[Artist]>,
+    pub songs: Box<[SongBrief]>,
+    pub albums: Box<[AlbumBrief]>,
+    pub artists: Box<[ArtistBrief]>,
 }
 
 impl SearchResult {
@@ -98,6 +98,14 @@ pub trait MusicPlayer {
     async fn library_songs_brief() -> Result<Box<[SongBrief]>, SerializableLibraryError>;
     /// Returns full information about the music library's songs.
     async fn library_songs_full() -> Result<Box<[Song]>, SerializableLibraryError>;
+    /// Returns brief information about the users playlists.
+    async fn library_playlists_brief() -> Result<Box<[PlaylistBrief]>, SerializableLibraryError>;
+    /// Returns full information about the users playlists.
+    async fn library_playlists_full() -> Result<Box<[Playlist]>, SerializableLibraryError>;
+    /// Return brief information about the users collections.
+    async fn library_collections_brief() -> Result<Box<[CollectionBrief]>, SerializableLibraryError>;
+    /// Return full information about the users collections.
+    async fn library_collections_full() -> Result<Box<[Collection]>, SerializableLibraryError>;
     /// Returns information about the health of the music library (are there any missing files, etc.)
     async fn library_health() -> Result<LibraryHealth, SerializableLibraryError>;
 
@@ -141,7 +149,7 @@ pub trait MusicPlayer {
     /// returns the current album.
     async fn current_album() -> Option<Album>;
     /// returns the current song.
-    async fn current_song() -> Option<Song>;
+    async fn current_song() -> Option<SongBrief>;
 
     // Rand (audio state)
     /// returns a random artist.
@@ -155,11 +163,11 @@ pub trait MusicPlayer {
     /// returns a list of artists, albums, and songs matching the given search query.
     async fn search(query: String, limit: usize) -> SearchResult;
     /// returns a list of artists matching the given search query.
-    async fn search_artist(query: String, limit: usize) -> Box<[Artist]>;
+    async fn search_artist(query: String, limit: usize) -> Box<[ArtistBrief]>;
     /// returns a list of albums matching the given search query.
-    async fn search_album(query: String, limit: usize) -> Box<[Album]>;
+    async fn search_album(query: String, limit: usize) -> Box<[AlbumBrief]>;
     /// returns a list of songs matching the given search query.
-    async fn search_song(query: String, limit: usize) -> Box<[Song]>;
+    async fn search_song(query: String, limit: usize) -> Box<[SongBrief]>;
 
     // Playback control.
     /// toggles playback (play/pause).
@@ -215,8 +223,6 @@ pub trait MusicPlayer {
     async fn queue_remove_range(range: Range<usize>) -> ();
 
     // Playlists.
-    /// Returns brief information about the users playlists.
-    async fn playlist_list() -> Box<[PlaylistBrief]>;
     /// create a new playlist with the given name (if it does not already exist).
     async fn playlist_get_or_create(name: String) -> Result<PlaylistId, SerializableLibraryError>;
     /// remove a playlist.
@@ -266,8 +272,6 @@ pub trait MusicPlayer {
 
     // Auto Curration commands.
     // (collections, radios, smart playlists, etc.)
-    /// Collections: Return brief information about the users auto curration collections.
-    async fn collection_list() -> Box<[CollectionBrief]>;
     /// Collections: get a collection by its ID.
     async fn collection_get(id: CollectionId) -> Option<Collection>;
     /// Collections: freeze a collection (convert it to a playlist).

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -153,11 +153,11 @@ pub trait MusicPlayer {
 
     // Rand (audio state)
     /// returns a random artist.
-    async fn rand_artist() -> Option<Artist>;
+    async fn rand_artist() -> Option<ArtistBrief>;
     /// returns a random album.
-    async fn rand_album() -> Option<Album>;
+    async fn rand_album() -> Option<AlbumBrief>;
     /// returns a random song.
-    async fn rand_song() -> Option<Song>;
+    async fn rand_song() -> Option<SongBrief>;
 
     // Search (fuzzy keys)
     /// returns a list of artists, albums, and songs matching the given search query.

--- a/core/src/state/library.rs
+++ b/core/src/state/library.rs
@@ -1,19 +1,23 @@
 use mecomp_storage::db::schemas::{
-    album::Album, artist::Artist, collection::Collection, dynamic::DynamicPlaylist,
-    playlist::Playlist, song::Song,
+    album::{Album, AlbumBrief},
+    artist::{Artist, ArtistBrief},
+    collection::{Collection, CollectionBrief},
+    dynamic::DynamicPlaylist,
+    playlist::{Playlist, PlaylistBrief},
+    song::{Song, SongBrief},
 };
 use serde::{Deserialize, Serialize};
 
 /// A brief representation of the library
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct LibraryBrief {
-    pub artists: usize,
-    pub albums: usize,
-    pub songs: usize,
-    pub playlists: usize,
-    pub collections: usize,
-    pub dynamic_playlists: usize,
+    pub artists: Box<[ArtistBrief]>,
+    pub albums: Box<[AlbumBrief]>,
+    pub songs: Box<[SongBrief]>,
+    pub playlists: Box<[PlaylistBrief]>,
+    pub collections: Box<[CollectionBrief]>,
+    pub dynamic_playlists: Box<[DynamicPlaylist]>,
 }
 
 /// A full representation of the library

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -2,7 +2,7 @@
 pub mod library;
 use std::{fmt::Display, time::Duration};
 
-use mecomp_storage::db::schemas::song::Song;
+use mecomp_storage::db::schemas::song::SongBrief;
 use serde::{Deserialize, Serialize};
 
 use crate::format_duration;
@@ -139,9 +139,9 @@ impl Display for Status {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct StateAudio {
-    pub queue: Box<[Song]>,
+    pub queue: Box<[SongBrief]>,
     pub queue_position: Option<usize>,
-    pub current_song: Option<Song>,
+    pub current_song: Option<SongBrief>,
     pub repeat_mode: RepeatMode,
     pub runtime: Option<StateRuntime>,
     pub status: Status,
@@ -205,6 +205,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use mecomp_storage::db::schemas::song::Song;
     use one_or_many::OneOrMany;
     use pretty_assertions::{assert_eq, assert_str_eq};
     use rstest::rstest;
@@ -281,7 +282,7 @@ mod tests {
     #[case::state_audio(
         StateAudio {
             queue: Box::new([
-                Song {
+                SongBrief {
                     id: Song::generate_id(),
                     title: "Song 1".into(),
                     artist: OneOrMany::None,
@@ -298,7 +299,7 @@ mod tests {
             ]),
             queue_position: Some(1),
             current_song: Some(
-                Song {
+                SongBrief {
                     id: Song::generate_id(),
                     title: "Song 1".into(),
                     artist: OneOrMany::None,

--- a/daemon/src/controller.rs
+++ b/daemon/src/controller.rs
@@ -638,7 +638,7 @@ impl MusicPlayer for MusicPlayerServer {
 
     /// returns a random artist.
     #[instrument]
-    async fn rand_artist(self, context: Context) -> Option<Artist> {
+    async fn rand_artist(self, context: Context) -> Option<ArtistBrief> {
         info!("Getting random artist");
         Artist::read_rand(&self.db, 1)
             .await
@@ -648,7 +648,7 @@ impl MusicPlayer for MusicPlayerServer {
     }
     /// returns a random album.
     #[instrument]
-    async fn rand_album(self, context: Context) -> Option<Album> {
+    async fn rand_album(self, context: Context) -> Option<AlbumBrief> {
         info!("Getting random album");
         Album::read_rand(&self.db, 1)
             .await
@@ -658,7 +658,7 @@ impl MusicPlayer for MusicPlayerServer {
     }
     /// returns a random song.
     #[instrument]
-    async fn rand_song(self, context: Context) -> Option<Song> {
+    async fn rand_song(self, context: Context) -> Option<SongBrief> {
         info!("Getting random song");
         Song::read_rand(&self.db, 1)
             .await

--- a/daemon/src/services/mod.rs
+++ b/daemon/src/services/mod.rs
@@ -29,7 +29,7 @@ pub mod radio;
 ///
 /// This function will return an error if there is an issue reading the songs from the database.
 #[inline]
-pub async fn get_songs_from_things<C: Connection>(
+pub(crate) async fn get_songs_from_things<C: Connection>(
     db: &Surreal<C>,
     things: &[RecordId],
 ) -> StorageResult<OneOrMany<Song>> {

--- a/mpris/src/lib.rs
+++ b/mpris/src/lib.rs
@@ -11,7 +11,7 @@ use mecomp_core::{
     state::{Percent, RepeatMode, StateAudio, Status},
     udp::{Event, Listener, Message, StateChange},
 };
-use mecomp_storage::db::schemas::song::Song;
+use mecomp_storage::db::schemas::song::SongBrief;
 use mpris_server::{
     LoopStatus, Metadata, PlaybackStatus, Property, Server, Signal, Time, TrackId,
     zbus::{Error as ZbusError, zvariant::ObjectPath},
@@ -306,7 +306,7 @@ impl Subscriber {
 }
 
 #[must_use]
-pub fn metadata_from_opt_song(song: Option<&Song>) -> Metadata {
+pub fn metadata_from_opt_song(song: Option<&SongBrief>) -> Metadata {
     song.map_or_else(
         || Metadata::builder().trackid(TrackId::NO_TRACK).build(),
         |song| {

--- a/storage/src/db/crud/album.rs
+++ b/storage/src/db/crud/album.rs
@@ -75,8 +75,11 @@ impl Album {
     pub async fn read_rand<C: Connection>(
         db: &Surreal<C>,
         limit: usize,
-    ) -> StorageResult<Vec<Self>> {
-        Ok(db.query(read_rand(TABLE_NAME, limit)).await?.take(0)?)
+    ) -> StorageResult<Vec<AlbumBrief>> {
+        Ok(db
+            .query(read_rand(Self::BRIEF_FIELDS, TABLE_NAME, limit))
+            .await?
+            .take(0)?)
     }
 
     #[instrument()]
@@ -339,12 +342,14 @@ mod tests {
         let mut album2 = create_album();
         album2.title = "Another Test Album".into();
 
-        let _ = Album::create(&db, album1.clone())
+        let album1 = Album::create(&db, album1.clone())
             .await?
-            .ok_or_else(|| anyhow!("Failed to create album"))?;
-        let _ = Album::create(&db, album2.clone())
+            .ok_or_else(|| anyhow!("Failed to create album"))?
+            .into();
+        let album2 = Album::create(&db, album2.clone())
             .await?
-            .ok_or_else(|| anyhow!("Failed to create album"))?;
+            .ok_or_else(|| anyhow!("Failed to create album"))?
+            .into();
 
         // n = # records
         let read = Album::read_rand(&db, 2).await?;

--- a/storage/src/db/crud/artist.rs
+++ b/storage/src/db/crud/artist.rs
@@ -11,11 +11,11 @@ use crate::{
                 add_album, add_album_to_artists, add_songs, read_albums, read_by_name,
                 read_by_names, read_songs, remove_songs,
             },
-            generic::{full_text_search, read_many, read_rand},
+            generic::{read_many, read_rand},
         },
         schemas::{
             album::{Album, AlbumId},
-            artist::{Artist, ArtistChangeSet, ArtistId, TABLE_NAME},
+            artist::{Artist, ArtistBrief, ArtistChangeSet, ArtistId, TABLE_NAME},
             song::{Song, SongId},
         },
     },
@@ -99,6 +99,14 @@ impl Artist {
     }
 
     #[instrument]
+    pub async fn read_all_brief<C: Connection>(db: &Surreal<C>) -> StorageResult<Vec<ArtistBrief>> {
+        Ok(db
+            .query(format!("SELECT {} FROM artist;", Self::BRIEF_FIELDS))
+            .await?
+            .take(0)?)
+    }
+
+    #[instrument]
     pub async fn read<C: Connection>(db: &Surreal<C>, id: ArtistId) -> StorageResult<Option<Self>> {
         Ok(db.select(id).await?)
     }
@@ -136,10 +144,11 @@ impl Artist {
         db: &Surreal<C>,
         query: &str,
         limit: usize,
-    ) -> StorageResult<Vec<Self>> {
+    ) -> StorageResult<Vec<ArtistBrief>> {
         Ok(db
-            .query(full_text_search(TABLE_NAME, "name", limit))
-            .bind(("name", query.to_string()))
+            .query(format!("SELECT {},relevance FROM {TABLE_NAME} WHERE name @@ $query ORDER BY relevance DESC LIMIT $limit",Self::BRIEF_FIELDS))
+            .bind(("query", query.to_string()))
+            .bind(("limit", limit))
             .await?
             .take(0)?)
     }
@@ -400,12 +409,12 @@ mod tests {
 
         let found = Artist::search(&db, "foo", 2).await?;
         assert_eq!(found.len(), 2);
-        assert!(found.contains(&artist1));
-        assert!(found.contains(&artist2));
+        assert!(found.contains(&artist1.clone().into()));
+        assert!(found.contains(&artist2.into()));
 
         let found = Artist::search(&db, "bar", 1).await?;
         assert_eq!(found.len(), 1);
-        assert_eq!(found, vec![artist1]);
+        assert_eq!(found, vec![artist1.into()]);
         Ok(())
     }
 
@@ -531,14 +540,19 @@ mod tests {
     #[tokio::test]
     async fn test_read_all() -> Result<()> {
         let db = init_test_database().await?;
-        let album = create_artist();
+        let artist = create_artist();
 
-        let _ = Artist::create(&db, album.clone())
+        let artist = Artist::create(&db, artist)
             .await?
             .ok_or_else(|| anyhow!("Failed to create artist"))?;
 
         let read = Artist::read_all(&db).await?;
         assert!(!read.is_empty());
+        assert_eq!(read, vec![artist.clone()]);
+
+        let read = Artist::read_all_brief(&db).await?;
+        assert!(!read.is_empty());
+        assert_eq!(read, vec![artist.into()]);
         Ok(())
     }
 

--- a/storage/src/db/crud/artist.rs
+++ b/storage/src/db/crud/artist.rs
@@ -135,8 +135,11 @@ impl Artist {
     pub async fn read_rand<C: Connection>(
         db: &Surreal<C>,
         limit: usize,
-    ) -> StorageResult<Vec<Self>> {
-        Ok(db.query(read_rand(TABLE_NAME, limit)).await?.take(0)?)
+    ) -> StorageResult<Vec<ArtistBrief>> {
+        Ok(db
+            .query(read_rand(Self::BRIEF_FIELDS, TABLE_NAME, limit))
+            .await?
+            .take(0)?)
     }
 
     #[instrument]
@@ -370,12 +373,14 @@ mod tests {
         let mut artist2 = create_artist();
         artist2.name = "Another Test Artist".to_string();
 
-        let _ = Artist::create(&db, artist1.clone())
+        let artist1 = Artist::create(&db, artist1.clone())
             .await?
-            .ok_or_else(|| anyhow!("Failed to create artist"))?;
-        let _ = Artist::create(&db, artist2.clone())
+            .ok_or_else(|| anyhow!("Failed to create artist"))?
+            .into();
+        let artist2 = Artist::create(&db, artist2.clone())
             .await?
-            .ok_or_else(|| anyhow!("Failed to create artist"))?;
+            .ok_or_else(|| anyhow!("Failed to create artist"))?
+            .into();
 
         // n = # records
         let read = Artist::read_rand(&db, 2).await?;

--- a/storage/src/db/crud/collection.rs
+++ b/storage/src/db/crud/collection.rs
@@ -8,7 +8,9 @@ use crate::{
     db::{
         queries::collection::{add_songs, read_songs, remove_songs},
         schemas::{
-            collection::{Collection, CollectionChangeSet, CollectionId, TABLE_NAME},
+            collection::{
+                Collection, CollectionBrief, CollectionChangeSet, CollectionId, TABLE_NAME,
+            },
             playlist::Playlist,
             song::{Song, SongId},
         },
@@ -28,6 +30,13 @@ impl Collection {
     #[instrument]
     pub async fn read_all<C: Connection>(db: &Surreal<C>) -> StorageResult<Vec<Self>> {
         Ok(db.select(TABLE_NAME).await?)
+    }
+
+    #[instrument]
+    pub async fn read_all_brief<C: Connection>(
+        db: &Surreal<C>,
+    ) -> StorageResult<Vec<CollectionBrief>> {
+        Ok(db.query("SELECT id,name FROM collection;").await?.take(0)?)
     }
 
     #[instrument]
@@ -187,6 +196,11 @@ mod tests {
         Collection::create(&db, collection.clone()).await?;
         let result = Collection::read_all(&db).await?;
         assert!(!result.is_empty());
+        assert_eq!(result, vec![collection.clone()]);
+
+        let result = Collection::read_all_brief(&db).await?;
+        assert!(!result.is_empty());
+        assert_eq!(result, vec![collection.into()]);
         Ok(())
     }
 

--- a/storage/src/db/crud/song.rs
+++ b/storage/src/db/crud/song.rs
@@ -93,8 +93,11 @@ impl Song {
     pub async fn read_rand<C: Connection>(
         db: &Surreal<C>,
         limit: usize,
-    ) -> StorageResult<Vec<Self>> {
-        Ok(db.query(read_rand(TABLE_NAME, limit)).await?.take(0)?)
+    ) -> StorageResult<Vec<SongBrief>> {
+        Ok(db
+            .query(read_rand(Self::BRIEF_FIELDS, TABLE_NAME, limit))
+            .await?
+            .take(0)?)
     }
 
     #[instrument]
@@ -469,10 +472,12 @@ mod test {
     #[tokio::test]
     async fn test_read_rand() -> Result<()> {
         let db = init_test_database().await?;
-        let song1 =
-            create_song_with_overrides(&db, arb_song_case()(), SongChangeSet::default()).await?;
-        let song2 =
-            create_song_with_overrides(&db, arb_song_case()(), SongChangeSet::default()).await?;
+        let song1 = create_song_with_overrides(&db, arb_song_case()(), SongChangeSet::default())
+            .await?
+            .into();
+        let song2 = create_song_with_overrides(&db, arb_song_case()(), SongChangeSet::default())
+            .await?
+            .into();
 
         // n = # records
         let read = Song::read_rand(&db, 2).await?;

--- a/storage/src/db/queries/album.rs
+++ b/storage/src/db/queries/album.rs
@@ -114,7 +114,7 @@ pub fn add_songs() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_songs() -> impl IntoQuery {
-    read_related_out("album", ALBUM_TO_SONG)
+    read_related_out("*", "album", ALBUM_TO_SONG)
 }
 
 /// Query to remove songs from an album
@@ -166,7 +166,7 @@ pub fn remove_songs() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_artist() -> impl IntoQuery {
-    read_related_in("id", ARTIST_TO_ALBUM)
+    read_related_in("*", "id", ARTIST_TO_ALBUM)
 }
 
 #[cfg(test)]

--- a/storage/src/db/queries/analysis.rs
+++ b/storage/src/db/queries/analysis.rs
@@ -55,7 +55,7 @@ pub fn add_to_song() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_for_song() -> impl IntoQuery {
-    read_related_in("song", ANALYSIS_TO_SONG)
+    read_related_in("*", "song", ANALYSIS_TO_SONG)
 }
 
 /// Query to read the analyses for a list of songs
@@ -101,7 +101,7 @@ pub fn read_for_songs() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_song() -> impl IntoQuery {
-    read_related_out("id", ANALYSIS_TO_SONG)
+    read_related_out("*", "id", ANALYSIS_TO_SONG)
 }
 
 /// Query to read the songs for a list of analyses

--- a/storage/src/db/queries/artist.rs
+++ b/storage/src/db/queries/artist.rs
@@ -86,7 +86,7 @@ pub fn read_by_names() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_albums() -> impl IntoQuery {
-    read_related_out("id", ARTIST_TO_ALBUM)
+    read_related_out("*", "id", ARTIST_TO_ALBUM)
 }
 
 /// Query to relate an artist to an album.

--- a/storage/src/db/queries/collection.rs
+++ b/storage/src/db/queries/collection.rs
@@ -54,7 +54,7 @@ pub fn add_songs() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_songs() -> impl IntoQuery {
-    read_related_out("id", COLLECTION_TO_SONG)
+    read_related_out("*", "id", COLLECTION_TO_SONG)
 }
 
 /// Query to remove songs from a collection

--- a/storage/src/db/queries/generic.rs
+++ b/storage/src/db/queries/generic.rs
@@ -322,8 +322,8 @@ pub const fn read_many() -> impl IntoQuery {
 
 /// Query to read `n` items from the given `table` at random
 #[must_use]
-pub fn read_rand(table: &'static str, n: usize) -> impl IntoQuery {
-    format!("SELECT * FROM (SELECT VALUE id FROM {table} ORDER BY RAND() LIMIT {n})")
+pub fn read_rand(selection: &'static str, table: &'static str, n: usize) -> impl IntoQuery {
+    format!("SELECT {selection} FROM {table} ORDER BY RAND() LIMIT {n}")
 }
 
 #[cfg(test)]
@@ -364,8 +364,8 @@ mod query_validation_tests {
     )]
     #[case::read_many(read_many(), "SELECT * FROM $ids")]
     #[case::read_rand(
-        read_rand("song", 5),
-        "SELECT * FROM (SELECT VALUE id FROM song ORDER BY RAND() LIMIT 5)"
+        read_rand("*", "song", 5),
+        "SELECT * FROM song ORDER BY RAND() LIMIT 5"
     )]
     fn test_queries(#[case] statement: impl IntoQuery, #[case] expected: &str) {
         validate_query(statement, expected);

--- a/storage/src/db/queries/generic.rs
+++ b/storage/src/db/queries/generic.rs
@@ -32,16 +32,8 @@ use crate::{db::queries::parse_query, errors::Error};
 /// );
 /// ```
 #[must_use]
-pub fn relate<Source: AsRef<str>, Target: AsRef<str>, Rel: AsRef<str>>(
-    source: Source,
-    target: Target,
-    rel: Rel,
-) -> impl IntoQuery {
-    fn relate_statement(source: &str, target: &str, rel: &str) -> impl IntoQuery + use<> {
-        parse_query(format!("RELATE ${source}->{rel}->${target}"))
-    }
-
-    relate_statement(source.as_ref(), target.as_ref(), rel.as_ref())
+pub fn relate(source: &'static str, target: &'static str, rel: &'static str) -> impl IntoQuery {
+    parse_query(format!("RELATE ${source}->{rel}->${target}"))
 }
 
 /// Query to unrelate two tables.
@@ -66,16 +58,8 @@ pub fn relate<Source: AsRef<str>, Target: AsRef<str>, Rel: AsRef<str>>(
 /// );
 /// ```
 #[must_use]
-pub fn unrelate<Source: AsRef<str>, Target: AsRef<str>, Rel: AsRef<str>>(
-    source: Source,
-    target: Target,
-    rel: Rel,
-) -> impl IntoQuery {
-    fn unrelate_statement(source: &str, target: &str, rel: &str) -> impl IntoQuery + use<> {
-        parse_query(format!("DELETE ${source}->{rel} WHERE out IN ${target}"))
-    }
-
-    unrelate_statement(source.as_ref(), target.as_ref(), rel.as_ref())
+pub fn unrelate(source: &'static str, target: &'static str, rel: &'static str) -> impl IntoQuery {
+    parse_query(format!("DELETE ${source}->{rel} WHERE out IN ${target}"))
 }
 /// Query to read items related to a source.
 ///
@@ -92,22 +76,19 @@ pub fn unrelate<Source: AsRef<str>, Target: AsRef<str>, Rel: AsRef<str>>(
 /// use surrealdb::opt::IntoQuery;
 ///
 /// // Example: read all the songs of an album
-/// let statement = read_related_out("album", "album_to_song");
+/// let statement = read_related_out("*", "album", "album_to_song");
 /// assert_eq!(
 ///     statement.into_query().unwrap(),
 ///     "SELECT * FROM $album->album_to_song.out".into_query().unwrap()
 /// );
 /// ```
 #[must_use]
-pub fn read_related_out<Source: AsRef<str>, Rel: AsRef<str>>(
-    source: Source,
-    rel: Rel,
+pub fn read_related_out(
+    selection: &'static str,
+    source: &'static str,
+    rel: &'static str,
 ) -> impl IntoQuery {
-    fn read_related_statement(source: &str, rel: &str) -> impl IntoQuery + use<> {
-        parse_query(format!("SELECT * FROM ${source}->{rel}.out"))
-    }
-
-    read_related_statement(source.as_ref(), rel.as_ref())
+    parse_query(format!("SELECT {selection} FROM ${source}->{rel}.out"))
 }
 
 /// Query to read items related to a target
@@ -126,22 +107,19 @@ pub fn read_related_out<Source: AsRef<str>, Rel: AsRef<str>>(
 /// use surrealdb::opt::IntoQuery;
 ///
 /// // Example: read the artist of an album
-/// let statement = read_related_in("album", "artist_to_album");
+/// let statement = read_related_in("*", "album", "artist_to_album");
 /// assert_eq!(
 ///    statement.as_str().unwrap(),
 ///   "SELECT * FROM $album<-artist_to_album.in"
 /// );
 /// ```
 #[must_use]
-pub fn read_related_in<Target: AsRef<str>, Rel: AsRef<str>>(
-    target: Target,
-    rel: Rel,
+pub fn read_related_in(
+    selection: &'static str,
+    target: &'static str,
+    rel: &'static str,
 ) -> impl IntoQuery {
-    fn read_related_statement(target: &str, rel: &str) -> impl IntoQuery + use<> {
-        parse_query(format!("SELECT * FROM ${target}<-{rel}.in"))
-    }
-
-    read_related_statement(target.as_ref(), rel.as_ref())
+    parse_query(format!("SELECT {selection} FROM ${target}<-{rel}.in"))
 }
 
 /// Struct to assist deserializing the results of the count queries
@@ -316,46 +294,6 @@ pub fn count_orphaned_both<Table: AsRef<str>, Rel1: AsRef<str>, Rel2: AsRef<str>
     count_orphaned_both_statement(table.as_ref(), rel1.as_ref(), rel2.as_ref())
 }
 
-/// Query to run a full text search on a given field of a given table.
-///
-/// Compiles to:
-/// ```sql, ignore
-/// SELECT * FROM table WHERE field @@ $field ORDER BY relevance DESC LIMIT limit
-/// ```
-///
-/// # Example
-///
-/// ```ignore
-/// # use pretty_assertions::assert_eq;
-/// use mecomp_storage::db::crud::queries::generic::full_text_search;
-/// use surrealdb::opt::IntoQuery;
-///
-/// // Example: search for songs with the word "hello" in the title
-/// let statement = full_text_search("song", "title", 10);
-/// assert_eq!(
-///    statement.into_query().unwrap(),
-///   "SELECT * FROM song WHERE title @@ $title ORDER BY relevance DESC LIMIT 10".into_query().unwrap()
-/// );
-/// ```
-#[must_use]
-pub fn full_text_search<Table: AsRef<str>, Field: AsRef<str>>(
-    table: Table,
-    field: Field,
-    limit: usize,
-) -> impl IntoQuery {
-    fn full_text_search_statement(
-        table: &str,
-        field: &str,
-        limit: usize,
-    ) -> impl IntoQuery + use<> {
-        parse_query(format!(
-            "SELECT * FROM {table} WHERE {field} @@ ${field} ORDER BY relevance DESC LIMIT {limit}"
-        ))
-    }
-
-    full_text_search_statement(table.as_ref(), field.as_ref(), limit)
-}
-
 /// Query to read many items from a table.
 ///
 /// Compiles to:
@@ -408,11 +346,11 @@ mod query_validation_tests {
         "DELETE $artist->artist_to_album WHERE out IN $album"
     )]
     #[case::read_related_out(
-        read_related_out("album", "album_to_song"),
+        read_related_out("*", "album", "album_to_song"),
         "SELECT * FROM $album->album_to_song.out"
     )]
     #[case::read_related_in(
-        read_related_in("album", "artist_to_album"),
+        read_related_in("*", "album", "artist_to_album"),
         "SELECT * FROM $album<-artist_to_album.in"
     )]
     #[case::count(count("song"), "SELECT count() FROM song GROUP ALL")]
@@ -423,10 +361,6 @@ mod query_validation_tests {
     #[case::count_orphaned_both(
         count_orphaned_both("artist", "artist_to_album", "artist_to_song"),
         "SELECT count() FROM artist WHERE count(->artist_to_album) = 0 AND count(->artist_to_song) = 0 GROUP ALL"
-    )]
-    #[case::full_text_search(
-        full_text_search("song", "title", 10),
-        "SELECT * FROM song WHERE title @@ $title ORDER BY relevance DESC LIMIT 10"
     )]
     #[case::read_many(read_many(), "SELECT * FROM $ids")]
     #[case::read_rand(

--- a/storage/src/db/queries/playlist.rs
+++ b/storage/src/db/queries/playlist.rs
@@ -51,7 +51,7 @@ pub fn add_songs() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_songs() -> impl IntoQuery {
-    read_related_out("id", PLAYLIST_TO_SONG)
+    read_related_out("*", "id", PLAYLIST_TO_SONG)
 }
 
 /// Query to remove songs from a playlist

--- a/storage/src/db/queries/song.rs
+++ b/storage/src/db/queries/song.rs
@@ -60,7 +60,7 @@ pub fn read_song_by_path() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_album() -> impl IntoQuery {
-    read_related_in("id", ALBUM_TO_SONG)
+    read_related_in("*", "id", ALBUM_TO_SONG)
 }
 
 /// Query to read the artist of a song
@@ -86,7 +86,7 @@ pub fn read_album() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_artist() -> impl IntoQuery {
-    read_related_in("id", ARTIST_TO_SONG)
+    read_related_in("*", "id", ARTIST_TO_SONG)
 }
 
 /// Query to read the album artist of a song
@@ -139,7 +139,7 @@ pub const fn read_album_artist() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_playlists() -> impl IntoQuery {
-    read_related_in("id", PLAYLIST_TO_SONG)
+    read_related_in("*", "id", PLAYLIST_TO_SONG)
 }
 
 /// Query to read the collections a song is in
@@ -166,7 +166,7 @@ pub fn read_playlists() -> impl IntoQuery {
 #[must_use]
 #[inline]
 pub fn read_collections() -> impl IntoQuery {
-    read_related_in("id", COLLECTION_TO_SONG)
+    read_related_in("*", "id", COLLECTION_TO_SONG)
 }
 
 #[cfg(test)]

--- a/storage/src/db/schemas/album.rs
+++ b/storage/src/db/schemas/album.rs
@@ -35,7 +35,7 @@ pub struct Album {
     /// Release year of this [`Album`].
     #[cfg_attr(feature = "db", field(dt = "option<int>"))]
     #[cfg_attr(feature = "serde", serde(default))]
-    pub release: Option<i32>,
+    pub release: Option<u32>,
     /// Total runtime of this [`Album`].
     #[cfg_attr(
         feature = "db",
@@ -76,6 +76,7 @@ RETURN IF $count IS NONE { 0 } ELSE IF $count.len() == 0 { 0 } ELSE { ($count[0]
 }
 
 impl Album {
+    pub const BRIEF_FIELDS: &'static str = "id,title,artist,release,discs,genre";
     #[must_use]
     #[inline]
     pub fn generate_id() -> AlbumId {
@@ -104,9 +105,7 @@ pub struct AlbumBrief {
     pub id: AlbumId,
     pub title: String,
     pub artist: OneOrMany<String>,
-    pub release: Option<i32>,
-    pub runtime: Duration,
-    pub song_count: usize,
+    pub release: Option<u32>,
     pub discs: u32,
     pub genre: OneOrMany<String>,
 }
@@ -119,8 +118,6 @@ impl From<Album> for AlbumBrief {
             title: album.title,
             artist: album.artist,
             release: album.release,
-            runtime: album.runtime,
-            song_count: album.song_count,
             discs: album.discs,
             genre: album.genre,
         }
@@ -135,8 +132,6 @@ impl From<&Album> for AlbumBrief {
             title: album.title.clone(),
             artist: album.artist.clone(),
             release: album.release,
-            runtime: album.runtime,
-            song_count: album.song_count,
             discs: album.discs,
             genre: album.genre.clone(),
         }
@@ -171,8 +166,6 @@ mod tests {
             title: "test".into(),
             artist: OneOrMany::One("test".into()),
             release: Some(2021),
-            runtime: Duration::from_secs(0),
-            song_count: 0,
             discs: 1,
             genre: OneOrMany::One("test".into()),
         }

--- a/storage/src/db/schemas/artist.rs
+++ b/storage/src/db/schemas/artist.rs
@@ -81,6 +81,8 @@ RETURN $count;
 }
 
 impl Artist {
+    pub const BRIEF_FIELDS: &'static str = "id,name";
+
     #[must_use]
     #[inline]
     pub fn generate_id() -> ArtistId {
@@ -102,9 +104,6 @@ pub struct ArtistChangeSet {
 pub struct ArtistBrief {
     pub id: ArtistId,
     pub name: String,
-    pub runtime: std::time::Duration,
-    pub albums: usize,
-    pub songs: usize,
 }
 
 impl From<Artist> for ArtistBrief {
@@ -113,9 +112,6 @@ impl From<Artist> for ArtistBrief {
         Self {
             id: artist.id,
             name: artist.name,
-            runtime: artist.runtime,
-            albums: artist.album_count,
-            songs: artist.song_count,
         }
     }
 }
@@ -126,9 +122,6 @@ impl From<&Artist> for ArtistBrief {
         Self {
             id: artist.id.clone(),
             name: artist.name.clone(),
-            runtime: artist.runtime,
-            albums: artist.album_count,
-            songs: artist.song_count,
         }
     }
 }
@@ -156,9 +149,6 @@ mod tests {
         ArtistBrief {
             id: RecordId::from((TABLE_NAME, "id")),
             name: "artist".into(),
-            runtime: Duration::from_secs(3600),
-            albums: 10,
-            songs: 100,
         }
     }
 

--- a/storage/src/db/schemas/collection.rs
+++ b/storage/src/db/schemas/collection.rs
@@ -58,6 +58,8 @@ RETURN IF $count IS NONE { 0 } ELSE IF $count.len() == 0 { 0 } ELSE { ($count[0]
 }
 
 impl Collection {
+    pub const BRIEF_FIELDS: &'static str = "id,name";
+
     #[must_use]
     #[inline]
     pub fn generate_id() -> CollectionId {
@@ -77,8 +79,6 @@ pub struct CollectionChangeSet {
 pub struct CollectionBrief {
     pub id: CollectionId,
     pub name: String,
-    pub runtime: std::time::Duration,
-    pub songs: usize,
 }
 
 impl From<Collection> for CollectionBrief {
@@ -87,8 +87,6 @@ impl From<Collection> for CollectionBrief {
         Self {
             id: collection.id,
             name: collection.name,
-            runtime: collection.runtime,
-            songs: collection.song_count,
         }
     }
 }
@@ -99,8 +97,6 @@ impl From<&Collection> for CollectionBrief {
         Self {
             id: collection.id.clone(),
             name: collection.name.clone(),
-            runtime: collection.runtime,
-            songs: collection.song_count,
         }
     }
 }
@@ -127,8 +123,6 @@ mod tests {
         CollectionBrief {
             id: RecordId::from((TABLE_NAME, "id")),
             name: "collection".into(),
-            runtime: Duration::from_secs(3600),
-            songs: 100,
         }
     }
 

--- a/storage/src/db/schemas/playlist.rs
+++ b/storage/src/db/schemas/playlist.rs
@@ -58,6 +58,8 @@ RETURN IF $count IS NONE { 0 } ELSE IF $count.len() == 0 { 0 } ELSE { ($count[0]
 }
 
 impl Playlist {
+    pub const BRIEF_FIELDS: &'static str = "id,name";
+
     #[must_use]
     #[inline]
     pub fn generate_id() -> PlaylistId {
@@ -92,8 +94,6 @@ impl PlaylistChangeSet {
 pub struct PlaylistBrief {
     pub id: PlaylistId,
     pub name: String,
-    pub runtime: std::time::Duration,
-    pub songs: usize,
 }
 
 impl From<Playlist> for PlaylistBrief {
@@ -102,8 +102,6 @@ impl From<Playlist> for PlaylistBrief {
         Self {
             id: playlist.id,
             name: playlist.name,
-            runtime: playlist.runtime,
-            songs: playlist.song_count,
         }
     }
 }
@@ -114,8 +112,6 @@ impl From<&Playlist> for PlaylistBrief {
         Self {
             id: playlist.id.clone(),
             name: playlist.name.clone(),
-            runtime: playlist.runtime,
-            songs: playlist.song_count,
         }
     }
 }
@@ -142,8 +138,6 @@ mod tests {
         PlaylistBrief {
             id: RecordId::from((TABLE_NAME, "id")),
             name: "playlist".into(),
-            runtime: Duration::from_secs(3600),
-            songs: 100,
         }
     }
 

--- a/tui/src/state/library.rs
+++ b/tui/src/state/library.rs
@@ -9,7 +9,7 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
 };
 
-use mecomp_core::{rpc::MusicPlayerClient, state::library::LibraryFull};
+use mecomp_core::{rpc::MusicPlayerClient, state::library::LibraryBrief};
 
 use crate::termination::Interrupted;
 
@@ -19,14 +19,14 @@ use super::action::LibraryAction;
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct LibraryState {
-    state_tx: UnboundedSender<LibraryFull>,
+    state_tx: UnboundedSender<LibraryBrief>,
 }
 
 impl LibraryState {
     /// create a new library state store, and return the receiver for listening to state updates.
     #[must_use]
-    pub fn new() -> (Self, UnboundedReceiver<LibraryFull>) {
-        let (state_tx, state_rx) = unbounded_channel::<LibraryFull>();
+    pub fn new() -> (Self, UnboundedReceiver<LibraryBrief>) {
+        let (state_tx, state_rx) = unbounded_channel::<LibraryBrief>();
 
         (Self { state_tx }, state_rx)
     }
@@ -148,9 +148,9 @@ impl LibraryState {
     }
 }
 
-async fn get_library(daemon: Arc<MusicPlayerClient>) -> anyhow::Result<LibraryFull> {
+async fn get_library(daemon: Arc<MusicPlayerClient>) -> anyhow::Result<LibraryBrief> {
     let ctx = tarpc::context::current();
-    Ok(daemon.library_full(ctx).await??)
+    Ok(daemon.library_brief(ctx).await??)
 }
 
 /// initiate a rescan and wait until it's done

--- a/tui/src/state/mod.rs
+++ b/tui/src/state/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use action::Action;
 use mecomp_core::{
     rpc::{MusicPlayerClient, SearchResult},
-    state::{StateAudio, library::LibraryFull},
+    state::{StateAudio, library::LibraryBrief},
 };
 use tokio::sync::{
     broadcast,
@@ -47,7 +47,7 @@ struct Senders {
 pub struct Receivers {
     pub audio: UnboundedReceiver<StateAudio>,
     pub search: UnboundedReceiver<SearchResult>,
-    pub library: UnboundedReceiver<LibraryFull>,
+    pub library: UnboundedReceiver<LibraryBrief>,
     pub view: UnboundedReceiver<ActiveView>,
     pub popup: UnboundedReceiver<Option<PopupType>>,
     pub component: UnboundedReceiver<component::ActiveComponent>,

--- a/tui/src/test_utils.rs
+++ b/tui/src/test_utils.rs
@@ -1,7 +1,12 @@
-use mecomp_core::{rpc::SearchResult, state::library::LibraryFull};
+use mecomp_core::{rpc::SearchResult, state::library::LibraryBrief};
 use mecomp_storage::db::schemas::{
-    Id, RecordId, album::Album, artist::Artist, collection::Collection, dynamic::DynamicPlaylist,
-    playlist::Playlist, song::Song,
+    Id, RecordId,
+    album::{Album, AlbumBrief},
+    artist::{Artist, ArtistBrief},
+    collection::{Collection, CollectionBrief},
+    dynamic::DynamicPlaylist,
+    playlist::{Playlist, PlaylistBrief},
+    song::{Song, SongBrief},
 };
 use one_or_many::OneOrMany;
 use ratatui::{Terminal, backend::TestBackend, layout::Rect};
@@ -75,6 +80,7 @@ pub fn state_with_everything() -> AppState {
         extension: "mp3".into(),
         path: "test.mp3".into(),
     };
+    let song_brief: SongBrief = song.clone().into();
     let artist = Artist {
         id: artist_id.clone().into(),
         name: song.artist[0].clone(),
@@ -82,6 +88,7 @@ pub fn state_with_everything() -> AppState {
         album_count: 1,
         song_count: 1,
     };
+    let artist_brief: ArtistBrief = artist.clone().into();
     let album = Album {
         id: album_id.clone().into(),
         title: song.album.clone(),
@@ -92,18 +99,21 @@ pub fn state_with_everything() -> AppState {
         discs: 1,
         genre: song.genre.clone(),
     };
+    let album_brief: AlbumBrief = album.clone().into();
     let collection = Collection {
         id: collection_id.clone().into(),
         name: "Collection 0".into(),
         runtime: song.runtime,
         song_count: 1,
     };
+    let collection_brief: CollectionBrief = collection.clone().into();
     let playlist = Playlist {
         id: playlist_id.clone().into(),
         name: "Test Playlist".into(),
         runtime: song.runtime,
         song_count: 1,
     };
+    let playlist_brief: PlaylistBrief = playlist.clone().into();
     let dynamic = DynamicPlaylist {
         id: dynamic_id.clone().into(),
         name: "Test Dynamic".into(),
@@ -112,12 +122,12 @@ pub fn state_with_everything() -> AppState {
 
     AppState {
         active_component: ActiveComponent::ContentView,
-        library: LibraryFull {
-            artists: vec![artist.clone()].into_boxed_slice(),
-            albums: vec![album.clone()].into_boxed_slice(),
-            songs: vec![song.clone()].into_boxed_slice(),
-            playlists: vec![playlist.clone()].into_boxed_slice(),
-            collections: vec![collection.clone()].into_boxed_slice(),
+        library: LibraryBrief {
+            artists: vec![artist_brief.clone()].into_boxed_slice(),
+            albums: vec![album_brief.clone()].into_boxed_slice(),
+            songs: vec![song_brief.clone()].into_boxed_slice(),
+            playlists: vec![playlist_brief.clone()].into_boxed_slice(),
+            collections: vec![collection_brief.clone()].into_boxed_slice(),
             dynamic_playlists: vec![dynamic.clone()].into_boxed_slice(),
         },
         additional_view_data: ViewData {
@@ -129,47 +139,47 @@ pub fn state_with_everything() -> AppState {
             album: Some(AlbumViewProps {
                 id: album_id,
                 album: album.clone(),
-                artists: OneOrMany::One(artist.clone()),
-                songs: vec![song.clone()].into_boxed_slice(),
+                artists: OneOrMany::One(artist_brief.clone()),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
             artist: Some(ArtistViewProps {
                 id: artist_id,
                 artist: artist.clone(),
-                albums: vec![album.clone()].into_boxed_slice(),
-                songs: vec![song.clone()].into_boxed_slice(),
+                albums: vec![album_brief.clone()].into_boxed_slice(),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
             song: Some(SongViewProps {
                 id: song_id,
                 song: song.clone(),
-                artists: OneOrMany::One(artist.clone()),
-                album: album.clone(),
-                playlists: vec![playlist.clone()].into_boxed_slice(),
-                collections: vec![collection.clone()].into_boxed_slice(),
+                artists: OneOrMany::One(artist_brief.clone()),
+                album: album_brief.clone(),
+                playlists: vec![playlist_brief.clone()].into_boxed_slice(),
+                collections: vec![collection_brief.clone()].into_boxed_slice(),
             }),
             collection: Some(CollectionViewProps {
                 id: collection_id,
                 collection,
-                songs: vec![song.clone()].into_boxed_slice(),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
             playlist: Some(PlaylistViewProps {
                 id: playlist_id,
                 playlist,
-                songs: vec![song.clone()].into_boxed_slice(),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
             dynamic_playlist: Some(DynamicPlaylistViewProps {
                 id: dynamic_id,
                 dynamic_playlist: dynamic,
-                songs: vec![song.clone()].into_boxed_slice(),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
             radio: Some(RadioViewProps {
                 count: 1,
-                songs: vec![song.clone()].into_boxed_slice(),
+                songs: vec![song_brief.clone()].into_boxed_slice(),
             }),
         },
         search: SearchResult {
-            songs: vec![song].into_boxed_slice(),
-            albums: vec![album].into_boxed_slice(),
-            artists: vec![artist].into_boxed_slice(),
+            songs: vec![song_brief].into_boxed_slice(),
+            albums: vec![album_brief].into_boxed_slice(),
+            artists: vec![artist_brief].into_boxed_slice(),
         },
         ..Default::default()
     }

--- a/tui/src/ui/app.rs
+++ b/tui/src/ui/app.rs
@@ -370,17 +370,17 @@ mod tests {
     use crossterm::event::KeyModifiers;
     use mecomp_core::{
         rpc::SearchResult,
-        state::{Percent, RepeatMode, StateAudio, StateRuntime, Status, library::LibraryFull},
+        state::{Percent, RepeatMode, StateAudio, StateRuntime, Status, library::LibraryBrief},
     };
-    use mecomp_storage::db::schemas::song::Song;
+    use mecomp_storage::db::schemas::song::{Song, SongBrief};
     use one_or_many::OneOrMany;
     use pretty_assertions::assert_eq;
     use rstest::{fixture, rstest};
     use tokio::sync::mpsc::unbounded_channel;
 
     #[fixture]
-    fn song() -> Song {
-        Song {
+    fn song() -> SongBrief {
+        SongBrief {
             id: Song::generate_id(),
             title: "Test Song".into(),
             artist: OneOrMany::One("Test Artist".into()),
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_move_with_search(song: Song) {
+    fn test_move_with_search(song: SongBrief) {
         let (tx, _) = tokio::sync::mpsc::unbounded_channel();
         let state = AppState::default();
         let mut app = App::new(&state, tx);
@@ -532,7 +532,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_move_with_audio(song: Song) {
+    fn test_move_with_audio(song: SongBrief) {
         let (tx, _) = tokio::sync::mpsc::unbounded_channel();
         let state = AppState::default();
         let mut app = App::new(&state, tx);
@@ -604,7 +604,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_move_with_library(song: Song) {
+    fn test_move_with_library(song: SongBrief) {
         let (tx, _) = tokio::sync::mpsc::unbounded_channel();
         let state = AppState {
             active_component: ActiveComponent::ContentView,
@@ -614,7 +614,7 @@ mod tests {
         let mut app = App::new(&state, tx);
 
         let state = AppState {
-            library: LibraryFull {
+            library: LibraryBrief {
                 songs: vec![song].into_boxed_slice(),
                 ..Default::default()
             },
@@ -626,7 +626,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_move_with_view(song: Song) {
+    fn test_move_with_view(song: SongBrief) {
         let (tx, _) = tokio::sync::mpsc::unbounded_channel();
         let state = AppState {
             active_component: ActiveComponent::ContentView,

--- a/tui/src/ui/components/content_view/views/album.rs
+++ b/tui/src/ui/components/content_view/views/album.rs
@@ -3,7 +3,7 @@
 use std::{ops::Not, sync::Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
-use mecomp_storage::db::schemas::album::Album;
+use mecomp_storage::db::schemas::album::AlbumBrief;
 use ratatui::{
     layout::{Margin, Rect},
     style::{Style, Stylize},
@@ -43,7 +43,7 @@ pub struct LibraryAlbumsView {
 }
 
 struct Props {
-    albums: Box<[Album]>,
+    albums: Box<[AlbumBrief]>,
     sort_mode: AlbumSort,
 }
 
@@ -251,10 +251,10 @@ impl ComponentRender<RenderProps> for LibraryAlbumsView {
 #[cfg(test)]
 mod sort_mode_tests {
     use super::*;
+    use mecomp_storage::db::schemas::album::Album;
     use one_or_many::OneOrMany;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::time::Duration;
 
     #[rstest]
     #[case(AlbumSort::Title, AlbumSort::Artist)]
@@ -276,33 +276,27 @@ mod sort_mode_tests {
     #[rstest]
     fn test_sort_items() {
         let mut albums = vec![
-            Album {
+            AlbumBrief {
                 id: Album::generate_id(),
                 title: "C".into(),
                 artist: OneOrMany::One("B".into()),
                 release: Some(2021),
-                song_count: 1,
-                runtime: Duration::from_secs(180),
                 discs: 1,
                 genre: OneOrMany::One("A".into()),
             },
-            Album {
+            AlbumBrief {
                 id: Album::generate_id(),
                 title: "B".into(),
                 artist: OneOrMany::One("A".into()),
                 release: Some(2022),
-                song_count: 1,
-                runtime: Duration::from_secs(180),
                 discs: 1,
                 genre: OneOrMany::One("C".into()),
             },
-            Album {
+            AlbumBrief {
                 id: Album::generate_id(),
                 title: "A".into(),
                 artist: OneOrMany::One("C".into()),
                 release: Some(2023),
-                song_count: 1,
-                runtime: Duration::from_secs(180),
                 discs: 1,
                 genre: OneOrMany::One("B".into()),
             },

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -3,7 +3,7 @@
 use std::{ops::Not as _, sync::Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
-use mecomp_storage::db::schemas::artist::Artist;
+use mecomp_storage::db::schemas::artist::ArtistBrief;
 use ratatui::{
     layout::{Margin, Rect},
     style::{Style, Stylize},
@@ -43,8 +43,8 @@ pub struct LibraryArtistsView {
 }
 
 struct Props {
-    artists: Box<[Artist]>,
-    sort_mode: NameSort<Artist>,
+    artists: Box<[ArtistBrief]>,
+    sort_mode: NameSort<ArtistBrief>,
 }
 impl Component for LibraryArtistsView {
     fn new(state: &AppState, action_tx: UnboundedSender<Action>) -> Self
@@ -250,15 +250,15 @@ impl ComponentRender<RenderProps> for LibraryArtistsView {
 #[cfg(test)]
 mod sort_mode_tests {
     use super::*;
+    use mecomp_storage::db::schemas::artist::Artist;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::time::Duration;
 
     #[rstest]
     #[case(NameSort::default(), NameSort::default())]
     fn test_sort_mode_next_prev(
-        #[case] mode: NameSort<Artist>,
-        #[case] expected: NameSort<Artist>,
+        #[case] mode: NameSort<ArtistBrief>,
+        #[case] expected: NameSort<ArtistBrief>,
     ) {
         assert_eq!(mode.next(), expected);
         assert_eq!(mode.next().prev(), mode);
@@ -266,33 +266,24 @@ mod sort_mode_tests {
 
     #[rstest]
     #[case(NameSort::default(), "Name")]
-    fn test_sort_mode_display(#[case] mode: NameSort<Artist>, #[case] expected: &str) {
+    fn test_sort_mode_display(#[case] mode: NameSort<ArtistBrief>, #[case] expected: &str) {
         assert_eq!(mode.to_string(), expected);
     }
 
     #[rstest]
     fn test_sort_items() {
         let mut artists = vec![
-            Artist {
+            ArtistBrief {
                 id: Artist::generate_id(),
                 name: "C".into(),
-                song_count: 1,
-                album_count: 1,
-                runtime: Duration::from_secs(180),
             },
-            Artist {
+            ArtistBrief {
                 id: Artist::generate_id(),
                 name: "B".into(),
-                song_count: 1,
-                album_count: 1,
-                runtime: Duration::from_secs(180),
             },
-            Artist {
+            ArtistBrief {
                 id: Artist::generate_id(),
                 name: "A".into(),
-                song_count: 1,
-                album_count: 1,
-                runtime: Duration::from_secs(180),
             },
         ];
 

--- a/tui/src/ui/components/content_view/views/collection.rs
+++ b/tui/src/ui/components/content_view/views/collection.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use mecomp_core::format_duration;
-use mecomp_storage::db::schemas::collection::Collection;
+use mecomp_storage::db::schemas::collection::CollectionBrief;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Margin, Rect},
     style::{Style, Stylize},
@@ -326,8 +326,8 @@ pub struct LibraryCollectionsView {
 }
 
 struct Props {
-    collections: Box<[Collection]>,
-    sort_mode: NameSort<Collection>,
+    collections: Box<[CollectionBrief]>,
+    sort_mode: NameSort<CollectionBrief>,
 }
 
 impl Component for LibraryCollectionsView {
@@ -499,15 +499,15 @@ impl ComponentRender<RenderProps> for LibraryCollectionsView {
 #[cfg(test)]
 mod sort_mode_tests {
     use super::*;
+    use mecomp_storage::db::schemas::collection::Collection;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::time::Duration;
 
     #[rstest]
     #[case(NameSort::default(), NameSort::default())]
     fn test_sort_mode_next_prev(
-        #[case] mode: NameSort<Collection>,
-        #[case] expected: NameSort<Collection>,
+        #[case] mode: NameSort<CollectionBrief>,
+        #[case] expected: NameSort<CollectionBrief>,
     ) {
         assert_eq!(mode.next(), expected);
         assert_eq!(mode.next().prev(), mode);
@@ -515,37 +515,31 @@ mod sort_mode_tests {
 
     #[rstest]
     #[case(NameSort::default(), "Name")]
-    fn test_sort_mode_display(#[case] mode: NameSort<Collection>, #[case] expected: &str) {
+    fn test_sort_mode_display(#[case] mode: NameSort<CollectionBrief>, #[case] expected: &str) {
         assert_eq!(mode.to_string(), expected);
     }
 
     #[rstest]
     fn test_sort_collectionss() {
-        let mut songs = vec![
-            Collection {
+        let mut collections = vec![
+            CollectionBrief {
                 id: Collection::generate_id(),
                 name: "C".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
-            Collection {
+            CollectionBrief {
                 id: Collection::generate_id(),
                 name: "A".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
-            Collection {
+            CollectionBrief {
                 id: Collection::generate_id(),
                 name: "B".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
         ];
 
-        NameSort::default().sort_items(&mut songs);
-        assert_eq!(songs[0].name, "A");
-        assert_eq!(songs[1].name, "B");
-        assert_eq!(songs[2].name, "C");
+        NameSort::default().sort_items(&mut collections);
+        assert_eq!(collections[0].name, "A");
+        assert_eq!(collections[1].name, "B");
+        assert_eq!(collections[2].name, "C");
     }
 }
 

--- a/tui/src/ui/components/content_view/views/mod.rs
+++ b/tui/src/ui/components/content_view/views/mod.rs
@@ -1,8 +1,13 @@
 pub mod dynamic;
 use mecomp_core::format_duration;
 use mecomp_storage::db::schemas::{
-    RecordId, album::Album, artist::Artist, collection::Collection, dynamic::DynamicPlaylist,
-    playlist::Playlist, song::Song,
+    RecordId,
+    album::{Album, AlbumBrief},
+    artist::{Artist, ArtistBrief},
+    collection::{Collection, CollectionBrief},
+    dynamic::DynamicPlaylist,
+    playlist::{Playlist, PlaylistBrief},
+    song::{Song, SongBrief},
 };
 use one_or_many::OneOrMany;
 use ratatui::{
@@ -46,8 +51,8 @@ pub struct ViewData {
 pub struct AlbumViewProps {
     pub id: RecordId,
     pub album: Album,
-    pub artists: OneOrMany<Artist>,
-    pub songs: Box<[Song]>,
+    pub artists: OneOrMany<ArtistBrief>,
+    pub songs: Box<[SongBrief]>,
 }
 
 impl ItemViewProps for AlbumViewProps {
@@ -123,8 +128,8 @@ impl ItemViewProps for AlbumViewProps {
 pub struct ArtistViewProps {
     pub id: RecordId,
     pub artist: Artist,
-    pub albums: Box<[Album]>,
-    pub songs: Box<[Song]>,
+    pub albums: Box<[AlbumBrief]>,
+    pub songs: Box<[SongBrief]>,
 }
 
 impl ItemViewProps for ArtistViewProps {
@@ -192,31 +197,31 @@ impl ItemViewProps for ArtistViewProps {
 pub struct CollectionViewProps {
     pub id: RecordId,
     pub collection: Collection,
-    pub songs: Box<[Song]>,
+    pub songs: Box<[SongBrief]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DynamicPlaylistViewProps {
     pub id: RecordId,
     pub dynamic_playlist: DynamicPlaylist,
-    pub songs: Box<[Song]>,
+    pub songs: Box<[SongBrief]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaylistViewProps {
     pub id: RecordId,
     pub playlist: Playlist,
-    pub songs: Box<[Song]>,
+    pub songs: Box<[SongBrief]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SongViewProps {
     pub id: RecordId,
     pub song: Song,
-    pub artists: OneOrMany<Artist>,
-    pub album: Album,
-    pub playlists: Box<[Playlist]>,
-    pub collections: Box<[Collection]>,
+    pub artists: OneOrMany<ArtistBrief>,
+    pub album: AlbumBrief,
+    pub playlists: Box<[PlaylistBrief]>,
+    pub collections: Box<[CollectionBrief]>,
 }
 
 impl ItemViewProps for SongViewProps {
@@ -315,7 +320,7 @@ pub struct RadioViewProps {
     /// The number of similar songs to get
     pub count: u32,
     /// The songs that are similar to the things
-    pub songs: Box<[Song]>,
+    pub songs: Box<[SongBrief]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -331,8 +336,8 @@ pub struct RandomViewProps {
 pub mod checktree_utils {
     use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
     use mecomp_storage::db::schemas::{
-        RecordId, album::Album, artist::Artist, collection::Collection, dynamic::DynamicPlaylist,
-        playlist::Playlist, song::Song,
+        RecordId, album::AlbumBrief, artist::ArtistBrief, collection::CollectionBrief,
+        dynamic::DynamicPlaylist, playlist::PlaylistBrief, song::SongBrief,
     };
     use ratatui::{
         layout::Position,
@@ -516,7 +521,7 @@ pub mod checktree_utils {
     ///
     /// Returns an error if the tree item cannot be created (e.g. duplicate ids)
     pub fn create_album_tree_item(
-        albums: &[Album],
+        albums: &[AlbumBrief],
     ) -> Result<CheckTreeItem<String>, std::io::Error> {
         CheckTreeItem::<String>::new_with_items(
             albums,
@@ -527,7 +532,7 @@ pub mod checktree_utils {
     }
 
     pub fn create_album_tree_leaf<'a>(
-        album: &Album,
+        album: &AlbumBrief,
         prefix: Option<Span<'a>>,
     ) -> CheckTreeItem<'a, String> {
         CheckTreeItem::new_leaf(
@@ -553,7 +558,7 @@ pub mod checktree_utils {
     ///
     /// Returns an error if the tree item cannot be created (e.g. duplicate ids)
     pub fn create_artist_tree_item(
-        artists: &[Artist],
+        artists: &[ArtistBrief],
     ) -> Result<CheckTreeItem<String>, std::io::Error> {
         CheckTreeItem::<String>::new_with_items(
             artists,
@@ -564,7 +569,7 @@ pub mod checktree_utils {
     }
 
     #[must_use]
-    pub fn create_artist_tree_leaf<'a>(artist: &Artist) -> CheckTreeItem<'a, String> {
+    pub fn create_artist_tree_leaf<'a>(artist: &ArtistBrief) -> CheckTreeItem<'a, String> {
         CheckTreeItem::new_leaf(
             artist.id.to_string(),
             Line::from(vec![Span::styled(
@@ -578,7 +583,7 @@ pub mod checktree_utils {
     ///
     /// Returns an error if the tree item cannot be created (e.g. duplicate ids)
     pub fn create_collection_tree_item(
-        collections: &[Collection],
+        collections: &[CollectionBrief],
     ) -> Result<CheckTreeItem<String>, std::io::Error> {
         CheckTreeItem::<String>::new_with_items(
             collections,
@@ -589,7 +594,9 @@ pub mod checktree_utils {
     }
 
     #[must_use]
-    pub fn create_collection_tree_leaf<'a>(collection: &Collection) -> CheckTreeItem<'a, String> {
+    pub fn create_collection_tree_leaf<'a>(
+        collection: &CollectionBrief,
+    ) -> CheckTreeItem<'a, String> {
         CheckTreeItem::new_leaf(
             collection.id.to_string(),
             Line::from(vec![Span::styled(
@@ -603,7 +610,7 @@ pub mod checktree_utils {
     ///
     /// Returns an error if the tree item cannot be created (e.g. duplicate ids)
     pub fn create_playlist_tree_item(
-        playlists: &[Playlist],
+        playlists: &[PlaylistBrief],
     ) -> Result<CheckTreeItem<String>, std::io::Error> {
         CheckTreeItem::<String>::new_with_items(
             playlists,
@@ -614,7 +621,7 @@ pub mod checktree_utils {
     }
 
     #[must_use]
-    pub fn create_playlist_tree_leaf<'a>(playlist: &Playlist) -> CheckTreeItem<'a, String> {
+    pub fn create_playlist_tree_leaf<'a>(playlist: &PlaylistBrief) -> CheckTreeItem<'a, String> {
         CheckTreeItem::new_leaf(
             playlist.id.to_string(),
             Line::from(vec![Span::styled(
@@ -654,7 +661,9 @@ pub mod checktree_utils {
     /// # Errors
     ///
     /// Returns an error if the tree item cannot be created (e.g. duplicate ids)
-    pub fn create_song_tree_item(songs: &[Song]) -> Result<CheckTreeItem<String>, std::io::Error> {
+    pub fn create_song_tree_item(
+        songs: &[SongBrief],
+    ) -> Result<CheckTreeItem<String>, std::io::Error> {
         CheckTreeItem::<String>::new_with_items(
             songs,
             "Songs",
@@ -663,7 +672,7 @@ pub mod checktree_utils {
         )
     }
 
-    pub fn create_song_tree_leaf<'a>(song: &Song) -> CheckTreeItem<'a, String> {
+    pub fn create_song_tree_leaf<'a>(song: &SongBrief) -> CheckTreeItem<'a, String> {
         CheckTreeItem::new_leaf(
             song.id.to_string(),
             Line::from(vec![

--- a/tui/src/ui/components/content_view/views/playlist.rs
+++ b/tui/src/ui/components/content_view/views/playlist.rs
@@ -4,7 +4,7 @@ use std::{ops::Not, sync::Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use mecomp_core::format_duration;
-use mecomp_storage::db::schemas::playlist::Playlist;
+use mecomp_storage::db::schemas::playlist::PlaylistBrief;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Margin, Position, Rect},
     style::{Style, Stylize},
@@ -197,7 +197,7 @@ impl Component for PlaylistView {
                 if let Some(props) = &self.props {
                     self.action_tx
                         .send(Action::Popup(PopupAction::Open(PopupType::PlaylistEditor(
-                            props.playlist.clone(),
+                            props.playlist.clone().into(),
                         ))))
                         .unwrap();
                 }
@@ -369,8 +369,8 @@ pub struct LibraryPlaylistsView {
 
 #[derive(Debug)]
 pub struct Props {
-    pub playlists: Box<[Playlist]>,
-    sort_mode: NameSort<Playlist>,
+    pub playlists: Box<[PlaylistBrief]>,
+    sort_mode: NameSort<PlaylistBrief>,
 }
 
 impl From<&AppState> for Props {
@@ -651,15 +651,15 @@ impl ComponentRender<RenderProps> for LibraryPlaylistsView {
 #[cfg(test)]
 mod sort_mode_tests {
     use super::*;
+    use mecomp_storage::db::schemas::playlist::Playlist;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::time::Duration;
 
     #[rstest]
     #[case(NameSort::default(), NameSort::default())]
     fn test_sort_mode_next_prev(
-        #[case] mode: NameSort<Playlist>,
-        #[case] expected: NameSort<Playlist>,
+        #[case] mode: NameSort<PlaylistBrief>,
+        #[case] expected: NameSort<PlaylistBrief>,
     ) {
         assert_eq!(mode.next(), expected);
         assert_eq!(mode.next().prev(), mode);
@@ -667,30 +667,24 @@ mod sort_mode_tests {
 
     #[rstest]
     #[case(NameSort::default(), "Name")]
-    fn test_sort_mode_display(#[case] mode: NameSort<Playlist>, #[case] expected: &str) {
+    fn test_sort_mode_display(#[case] mode: NameSort<PlaylistBrief>, #[case] expected: &str) {
         assert_eq!(mode.to_string(), expected);
     }
 
     #[rstest]
     fn test_sort_items() {
         let mut songs = vec![
-            Playlist {
+            PlaylistBrief {
                 id: Playlist::generate_id(),
                 name: "C".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
-            Playlist {
+            PlaylistBrief {
                 id: Playlist::generate_id(),
                 name: "A".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
-            Playlist {
+            PlaylistBrief {
                 id: Playlist::generate_id(),
                 name: "B".into(),
-                song_count: 0,
-                runtime: Duration::from_secs(0),
             },
         ];
 

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -3,7 +3,7 @@
 use std::{ops::Not, sync::Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
-use mecomp_storage::db::schemas::song::Song;
+use mecomp_storage::db::schemas::song::SongBrief;
 use ratatui::{
     layout::{Margin, Rect},
     style::{Style, Stylize},
@@ -43,7 +43,7 @@ pub struct LibrarySongsView {
 }
 
 pub(crate) struct Props {
-    pub(crate) songs: Box<[Song]>,
+    pub(crate) songs: Box<[SongBrief]>,
     pub(crate) sort_mode: SongSort,
 }
 
@@ -252,6 +252,7 @@ impl ComponentRender<RenderProps> for LibrarySongsView {
 #[cfg(test)]
 mod sort_mode_tests {
     use super::*;
+    use mecomp_storage::db::schemas::song::Song;
     use one_or_many::OneOrMany;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -281,7 +282,7 @@ mod sort_mode_tests {
     #[rstest]
     fn test_sort_songs() {
         let mut songs = vec![
-            Song {
+            SongBrief {
                 id: Song::generate_id(),
                 title: "C".into(),
                 artist: OneOrMany::One("B".into()),
@@ -295,7 +296,7 @@ mod sort_mode_tests {
                 extension: "mp3".into(),
                 path: "test.mp3".into(),
             },
-            Song {
+            SongBrief {
                 id: Song::generate_id(),
                 title: "B".into(),
                 artist: OneOrMany::One("A".into()),
@@ -309,7 +310,7 @@ mod sort_mode_tests {
                 extension: "mp3".into(),
                 path: "test.mp3".into(),
             },
-            Song {
+            SongBrief {
                 id: Song::generate_id(),
                 title: "A".into(),
                 artist: OneOrMany::One("C".into()),

--- a/tui/src/ui/components/content_view/views/sort_mode.rs
+++ b/tui/src/ui/components/content_view/views/sort_mode.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Display, marker::PhantomData};
 
 use mecomp_storage::db::schemas::{
-    album::Album, artist::Artist, collection::Collection, dynamic::DynamicPlaylist,
-    playlist::Playlist, song::Song,
+    album::AlbumBrief, artist::ArtistBrief, collection::CollectionBrief, dynamic::DynamicPlaylist,
+    playlist::PlaylistBrief, song::SongBrief,
 };
 
 use super::traits::SortMode;
@@ -29,7 +29,7 @@ impl Display for SongSort {
     }
 }
 
-impl SortMode<Song> for SongSort {
+impl SortMode<SongBrief> for SongSort {
     fn next(&self) -> Self {
         match self {
             Self::Title => Self::Artist,
@@ -50,7 +50,7 @@ impl SortMode<Song> for SongSort {
         }
     }
 
-    fn sort_items(&self, songs: &mut [Song]) {
+    fn sort_items(&self, songs: &mut [SongBrief]) {
         fn key<T: AsRef<str>>(input: T) -> String {
             input
                 .as_ref()
@@ -96,7 +96,7 @@ impl Display for AlbumSort {
     }
 }
 
-impl SortMode<Album> for AlbumSort {
+impl SortMode<AlbumBrief> for AlbumSort {
     fn next(&self) -> Self {
         match self {
             Self::Title => Self::Artist,
@@ -113,7 +113,7 @@ impl SortMode<Album> for AlbumSort {
         }
     }
 
-    fn sort_items(&self, albums: &mut [Album]) {
+    fn sort_items(&self, albums: &mut [AlbumBrief]) {
         fn key<T: AsRef<str>>(input: T) -> String {
             input
                 .as_ref()
@@ -174,7 +174,7 @@ macro_rules! impl_name_sortable {
     };
 }
 
-impl_name_sortable!(Artist, Collection, Playlist, DynamicPlaylist);
+impl_name_sortable!(ArtistBrief, CollectionBrief, PlaylistBrief, DynamicPlaylist);
 
 impl<T> SortMode<T> for NameSort<T>
 where

--- a/tui/src/ui/components/queuebar.rs
+++ b/tui/src/ui/components/queuebar.rs
@@ -2,7 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use mecomp_core::state::RepeatMode;
-use mecomp_storage::db::schemas::song::Song;
+use mecomp_storage::db::schemas::song::SongBrief;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Position, Rect},
     style::{Modifier, Style},
@@ -32,7 +32,7 @@ pub struct QueueBar {
 }
 
 pub struct Props {
-    pub(crate) queue: Box<[Song]>,
+    pub(crate) queue: Box<[SongBrief]>,
     pub(crate) current_position: Option<usize>,
     pub(crate) repeat_mode: RepeatMode,
 }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -37,7 +37,7 @@ use crossterm::{
 use mecomp_core::{
     config::Settings,
     rpc::{MusicPlayerClient, SearchResult},
-    state::{StateAudio, library::LibraryFull},
+    state::{StateAudio, library::LibraryBrief},
 };
 use mecomp_storage::db::schemas::{RecordId, album, artist, collection, dynamic, playlist, song};
 use one_or_many::OneOrMany;
@@ -56,7 +56,7 @@ pub struct AppState {
     pub active_component: ActiveComponent,
     pub audio: StateAudio,
     pub search: SearchResult,
-    pub library: LibraryFull,
+    pub library: LibraryBrief,
     pub active_view: ActiveView,
     pub additional_view_data: ViewData,
     pub settings: Settings,
@@ -253,6 +253,10 @@ async fn handle_additional_view_data(
                 daemon.library_song_get_playlists(Context::current(), song_id.clone()),
                 daemon.library_song_get_collections(Context::current(), song_id.clone()),
             ) {
+                let artists = artists.into_iter().map(Into::into).collect();
+                let album = album.into();
+                let playlists = playlists.into_iter().map(Into::into).collect();
+                let collections = collections.into_iter().map(Into::into).collect();
                 let song_view_props = SongViewProps {
                     id: song_id,
                     song,
@@ -283,6 +287,8 @@ async fn handle_additional_view_data(
                 daemon.library_album_get_artist(Context::current(), album_id.clone()),
                 daemon.library_album_get_songs(Context::current(), album_id.clone()),
             ) {
+                let artists = artists.into_iter().map(Into::into).collect();
+                let songs = songs.into_iter().map(Into::into).collect();
                 let album_view_props = AlbumViewProps {
                     id: album_id,
                     album,
@@ -311,6 +317,8 @@ async fn handle_additional_view_data(
                 daemon.library_artist_get_albums(Context::current(), artist_id.clone()),
                 daemon.library_artist_get_songs(Context::current(), artist_id.clone()),
             ) {
+                let albums = albums.into_iter().map(Into::into).collect();
+                let songs = songs.into_iter().map(Into::into).collect();
                 let artist_view_props = ArtistViewProps {
                     id: artist_id,
                     artist,
@@ -338,6 +346,7 @@ async fn handle_additional_view_data(
                 daemon.playlist_get(Context::current(), playlist_id.clone()),
                 daemon.playlist_get_songs(Context::current(), playlist_id.clone()),
             ) {
+                let songs = songs.into_iter().map(Into::into).collect();
                 let playlist_view_props = PlaylistViewProps {
                     id: playlist_id,
                     playlist,
@@ -364,10 +373,11 @@ async fn handle_additional_view_data(
                 daemon.dynamic_playlist_get(Context::current(), dynamic_playlist_id.clone()),
                 daemon.dynamic_playlist_get_songs(Context::current(), dynamic_playlist_id.clone()),
             ) {
+                let songs = songs.into_iter().map(Into::into).collect();
                 let dynamic_playlist_view_props = DynamicPlaylistViewProps {
                     id: dynamic_playlist_id,
-                    songs,
                     dynamic_playlist,
+                    songs,
                 };
                 Some(ViewData {
                     dynamic_playlist: Some(dynamic_playlist_view_props),
@@ -390,6 +400,7 @@ async fn handle_additional_view_data(
                 daemon.collection_get(Context::current(), collection_id.clone()),
                 daemon.collection_get_songs(Context::current(), collection_id.clone()),
             ) {
+                let songs = songs.into_iter().map(Into::into).collect();
                 let collection_view_props = CollectionViewProps {
                     id: collection_id,
                     collection,
@@ -412,6 +423,7 @@ async fn handle_additional_view_data(
                 .radio_get_similar(Context::current(), ids.clone(), count)
                 .await
             {
+                let songs = songs.into_iter().map(Into::into).collect();
                 Some(RadioViewProps { count, songs })
             } else {
                 None

--- a/tui/src/ui/widgets/popups/mod.rs
+++ b/tui/src/ui/widgets/popups/mod.rs
@@ -3,7 +3,7 @@ pub mod notification;
 pub mod playlist;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind};
-use mecomp_storage::db::schemas::{RecordId, dynamic::DynamicPlaylist, playlist::Playlist};
+use mecomp_storage::db::schemas::{RecordId, dynamic::DynamicPlaylist, playlist::PlaylistBrief};
 use ratatui::{
     layout::Position,
     prelude::Rect,
@@ -108,7 +108,7 @@ pub trait Popup: for<'a> ComponentRender<Rect> + Send + Sync {
 pub enum PopupType {
     Notification(Text<'static>),
     Playlist(Vec<RecordId>),
-    PlaylistEditor(Playlist),
+    PlaylistEditor(PlaylistBrief),
     DynamicPlaylistEditor(DynamicPlaylist),
 }
 

--- a/tui/src/ui/widgets/popups/playlist.rs
+++ b/tui/src/ui/widgets/popups/playlist.rs
@@ -11,7 +11,7 @@
 use std::{ops::Not, sync::Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
-use mecomp_storage::db::schemas::{RecordId, playlist::Playlist};
+use mecomp_storage::db::schemas::{RecordId, playlist::PlaylistBrief};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Margin, Position, Rect},
@@ -335,7 +335,11 @@ pub struct PlaylistEditor {
 
 impl PlaylistEditor {
     #[must_use]
-    pub fn new(state: &AppState, action_tx: UnboundedSender<Action>, playlist: Playlist) -> Self {
+    pub fn new(
+        state: &AppState,
+        action_tx: UnboundedSender<Action>,
+        playlist: PlaylistBrief,
+    ) -> Self {
         let mut input_box = InputBox::new(state, action_tx.clone());
         input_box.set_text(&playlist.name);
 
@@ -438,8 +442,6 @@ impl ComponentRender<Rect> for PlaylistEditor {
 
 #[cfg(test)]
 mod selector_tests {
-    use std::time::Duration;
-
     use super::*;
     use crate::{
         state::component::ActiveComponent,
@@ -450,7 +452,7 @@ mod selector_tests {
     use mecomp_core::{
         config::Settings,
         rpc::SearchResult,
-        state::{StateAudio, library::LibraryFull},
+        state::{StateAudio, library::LibraryBrief},
     };
     use mecomp_storage::db::schemas::playlist::Playlist;
     use pretty_assertions::assert_eq;
@@ -467,12 +469,10 @@ mod selector_tests {
             active_component: ActiveComponent::default(),
             audio: StateAudio::default(),
             search: SearchResult::default(),
-            library: LibraryFull {
-                playlists: vec![Playlist {
+            library: LibraryBrief {
+                playlists: vec![PlaylistBrief {
                     id: Playlist::generate_id(),
                     name: "playlist 1".into(),
-                    runtime: Duration::default(),
-                    song_count: 0,
                 }]
                 .into_boxed_slice(),
                 ..Default::default()
@@ -636,8 +636,6 @@ mod selector_tests {
 
 #[cfg(test)]
 mod editor_tests {
-    use std::time::Duration;
-
     use super::*;
     use crate::{
         state::component::ActiveComponent,
@@ -648,7 +646,7 @@ mod editor_tests {
     use mecomp_core::{
         config::Settings,
         rpc::SearchResult,
-        state::{StateAudio, library::LibraryFull},
+        state::{StateAudio, library::LibraryBrief},
     };
     use mecomp_storage::db::schemas::playlist::Playlist;
     use pretty_assertions::assert_eq;
@@ -661,7 +659,7 @@ mod editor_tests {
             active_component: ActiveComponent::default(),
             audio: StateAudio::default(),
             search: SearchResult::default(),
-            library: LibraryFull::default(),
+            library: LibraryBrief::default(),
             active_view: ActiveView::default(),
             additional_view_data: ViewData::default(),
             settings: Settings::default(),
@@ -669,12 +667,10 @@ mod editor_tests {
     }
 
     #[fixture]
-    fn playlist() -> Playlist {
-        Playlist {
+    fn playlist() -> PlaylistBrief {
+        PlaylistBrief {
             id: Playlist::generate_id(),
             name: "Test Playlist".into(),
-            runtime: Duration::default(),
-            song_count: 0,
         }
     }
 
@@ -686,7 +682,7 @@ mod editor_tests {
         #[case] terminal_size: (u16, u16),
         #[case] expected_area: Rect,
         state: AppState,
-        playlist: Playlist,
+        playlist: PlaylistBrief,
     ) {
         let (_, area) = setup_test_terminal(terminal_size.0, terminal_size.1);
         let action_tx = tokio::sync::mpsc::unbounded_channel().0;
@@ -696,7 +692,7 @@ mod editor_tests {
     }
 
     #[rstest]
-    fn test_playlist_editor_render(state: AppState, playlist: Playlist) -> Result<()> {
+    fn test_playlist_editor_render(state: AppState, playlist: PlaylistBrief) -> Result<()> {
         let (mut terminal, _) = setup_test_terminal(20, 5);
         let action_tx = tokio::sync::mpsc::unbounded_channel().0;
         let editor = PlaylistEditor::new(&state, action_tx, playlist);
@@ -718,7 +714,7 @@ mod editor_tests {
     }
 
     #[rstest]
-    fn test_playlist_editor_input(state: AppState, playlist: Playlist) {
+    fn test_playlist_editor_input(state: AppState, playlist: PlaylistBrief) {
         let (action_tx, mut action_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut editor = PlaylistEditor::new(&state, action_tx, playlist.clone());
 


### PR DESCRIPTION
closes #320

the benefits of this is that it often overhead by skipping the computed fields for many use cases where they simply aren't needed