### PR TITLE
refactor(daemon): remove `analysis` feature flag

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -40,7 +40,7 @@ name = "recluster"
 harness = false
 
 [features]
-default = ["cli", "dynamic_updates", "analysis"]
+default = ["cli", "dynamic_updates"]
 cli = [
     "dep:clap",
     "dep:clap_complete",
@@ -48,7 +48,6 @@ cli = [
 # otel_tracing = ["mecomp-core/otel_tracing"]
 # flame = ["mecomp-core/flame"]
 dynamic_updates = ["dep:notify-debouncer-full", "dep:notify"]
-analysis = ["mecomp-storage/analysis", "dep:mecomp-analysis"]
 
 [dependencies]
 # shared dependencies
@@ -69,8 +68,8 @@ walkdir = { workspace = true }
 
 # MECOMP dependencies
 mecomp-core = { workspace = true, features = ["rpc", "audio", "analysis"] }
-mecomp-storage = { workspace = true, features = ["serde", "db"] }
-mecomp-analysis = { workspace = true, optional = true }
+mecomp-storage = { workspace = true, features = ["serde", "db", "analysis"] }
+mecomp-analysis = { workspace = true }
 one-or-many = { workspace = true }
 mecomp-workspace-hack = { version = "0.1", path = "../mecomp-workspace-hack" }
 

--- a/daemon/src/services/library.rs
+++ b/daemon/src/services/library.rs
@@ -503,10 +503,7 @@ pub async fn health<C: Connection>(db: &Surreal<C>) -> Result<LibraryHealth, Err
         artists: count_artists(db).await?,
         albums: count_albums(db).await?,
         songs: count_songs(db).await?,
-        #[cfg(feature = "analysis")]
         unanalyzed_songs: Some(count_unanalyzed_songs(db).await?),
-        #[cfg(not(feature = "analysis"))]
-        unanalyzed_songs: None,
         playlists: count_playlists(db).await?,
         collections: count_collections(db).await?,
         dynamic_playlists: count_dynamic_playlists(db).await?,
@@ -940,10 +937,7 @@ mod tests {
         assert_eq!(health.artists, 0);
         assert_eq!(health.albums, 0);
         assert_eq!(health.songs, 0);
-        #[cfg(feature = "analysis")]
         assert_eq!(health.unanalyzed_songs, Some(0));
-        #[cfg(not(feature = "analysis"))]
-        assert_eq!(health.unanalyzed_songs, None);
         assert_eq!(health.playlists, 0);
         assert_eq!(health.collections, 0);
         assert_eq!(health.orphaned_artists, 0);

--- a/daemon/src/services/mod.rs
+++ b/daemon/src/services/mod.rs
@@ -16,7 +16,6 @@ use surrealdb::{Connection, Surreal};
 
 pub mod backup;
 pub mod library;
-#[cfg(feature = "analysis")]
 pub mod radio;
 
 /// Get the songs associated with every thing in the list.


### PR DESCRIPTION
We basically never use the daemon w/o analysis enabled, since analysis is what allows mecomp to do all the cool things that make it awesome.

So this commit removes the feature flag and refactors the code as it would be if the flag was enabled