### PR TITLE
feat(tui): make color theme configurable

### DIFF
--- a/core/Mecomp.toml
+++ b/core/Mecomp.toml
@@ -78,3 +78,27 @@ projection_method = "tsne"
 ## How many songs should be queried for when starting a radio.
 ## Default is 20.
 radio_count = 20
+##  The color scheme to use for the TUI.
+## Each color is either:
+## - a hex string in the format "#RRGGBB".
+##   example: "#FFFFFF" for white.
+## - a material design color name in format "<COLOR>_<SHADE>".
+##   so "pink", "red-900",  "light-blue_500", "red900", etc. are all invalid.
+##   but "PINK_900", "RED_900", "LIGHT_BLUE_500" are valid.
+##   - Exceptions are "WHITE" and "BLACK", which are always valid.
+[tui.colors]
+### app border colors
+app_border = "PINK_900"
+app_border_text = "PINK_300"
+### border colors
+border_unfocused = "RED_900"
+border_focused = "RED_200"
+### popup border color
+popup_border = "LIGHT_BLUE_500"
+### text colors
+text_normal = "WHITE"
+text_highlight = "RED_600"
+text_highlight_alt = "RED_200"
+### gauge colors, such as song progress bar
+gauge_filled = "WHITE"
+gauge_unfilled = "BLACK"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -154,6 +154,14 @@ impl<T> OnceLockDefault<T> {
     pub fn get(&self) -> &T {
         self.value.get().unwrap_or(&self.default)
     }
+
+    /// Checks if the cell has been initialized.
+    ///
+    /// This method never blocks.
+    #[inline]
+    pub fn is_initialized(&self) -> bool {
+        self.value.get().is_some()
+    }
 }
 
 impl<T> std::ops::Deref for OnceLockDefault<T> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -117,6 +117,54 @@ pub fn is_server_running(port: u16) -> bool {
     std::net::TcpStream::connect(format!("localhost:{port}")).is_ok()
 }
 
+/// A `OnceLock` that returns a default value if it has not been set yet.
+#[derive(Debug, Clone)]
+pub struct OnceLockDefault<T> {
+    value: std::sync::OnceLock<T>,
+    default: T,
+}
+
+impl<T> OnceLockDefault<T> {
+    /// Creates a new `OnceLockDefault` with the given default value.
+    #[inline]
+    pub const fn new(default: T) -> Self {
+        Self {
+            value: std::sync::OnceLock::new(),
+            default,
+        }
+    }
+
+    /// Initializes the contents of the cell to value.
+    ///
+    /// May block if another thread is currently attempting to initialize the cell.
+    /// The cell is guaranteed to contain a value when set returns, though not necessarily the one provided.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Ok(())` if the cell was uninitialized and `Err(value)` if the cell was already initialized.
+    #[inline]
+    pub fn set(&self, value: T) -> Result<(), T> {
+        self.value.set(value)
+    }
+
+    /// Gets the reference to the underlying value, if set. Otherwise returns a reference to the default value.
+    ///
+    /// This method never blocks.
+    #[inline]
+    pub fn get(&self) -> &T {
+        self.value.get().unwrap_or(&self.default)
+    }
+}
+
+impl<T> std::ops::Deref for OnceLockDefault<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::format_duration;

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -34,6 +34,9 @@ async fn main() -> anyhow::Result<()> {
     let config_file = Settings::get_config_path()?;
     let settings = Settings::init(config_file, flags.port, None)?;
 
+    // initialize colors
+    mecomp_tui::ui::colors::initialize_colors(settings.tui.colors.clone());
+
     // check if the server is running, and if it's not, try to start it
     #[cfg(feature = "autostart-daemon")]
     let server_process = MaybeDaemonHandler::start(settings.daemon.rpc_port).await?;

--- a/tui/src/ui/app.rs
+++ b/tui/src/ui/app.rs
@@ -279,14 +279,14 @@ impl ComponentRender<Rect> for App {
         let block = Block::bordered()
             .title_top(Span::styled(
                 "MECOMP",
-                Style::default().bold().fg(APP_BORDER_TEXT.into()),
+                Style::default().bold().fg((*APP_BORDER_TEXT).into()),
             ))
             .title_bottom(Span::styled(
                 "Tab/Shift+Tab to switch focus | Esc to quit",
-                Style::default().fg(APP_BORDER_TEXT.into()),
+                Style::default().fg((*APP_BORDER_TEXT).into()),
             ))
-            .border_style(Style::default().fg(APP_BORDER.into()))
-            .style(Style::default().fg(TEXT_NORMAL.into()));
+            .border_style(Style::default().fg((*APP_BORDER).into()))
+            .style(Style::default().fg((*TEXT_NORMAL).into()));
         let app_area = block.inner(area);
         debug_assert_eq!(area.inner(Margin::new(1, 1)), app_area);
 

--- a/tui/src/ui/components/content_view/views/album.rs
+++ b/tui/src/ui/components/content_view/views/album.rs
@@ -240,7 +240,7 @@ impl ComponentRender<RenderProps> for LibraryAlbumsView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             props.area,
             &mut self.tree_state.lock().unwrap(),

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -239,7 +239,7 @@ impl ComponentRender<RenderProps> for LibraryArtistsView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             props.area,
             &mut self.tree_state.lock().unwrap(),

--- a/tui/src/ui/components/content_view/views/collection.rs
+++ b/tui/src/ui/components/content_view/views/collection.rs
@@ -266,7 +266,7 @@ impl ComponentRender<RenderProps> for CollectionView {
                             "checked items"
                         },
                     )
-                    .fg(TEXT_HIGHLIGHT),
+                    .fg(*TEXT_HIGHLIGHT),
                 ]))
                 .italic()
                 .border_style(border_style);
@@ -296,7 +296,7 @@ impl ComponentRender<RenderProps> for CollectionView {
             frame.render_stateful_widget(
                 CheckTree::new(&items)
                     .unwrap()
-                    .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                    .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                     .experimental_scrollbar(Some(Scrollbar::new(
                         ScrollbarOrientation::VerticalRight,
                     ))),
@@ -308,7 +308,7 @@ impl ComponentRender<RenderProps> for CollectionView {
 
             frame.render_widget(
                 Line::from(text)
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -485,7 +485,7 @@ impl ComponentRender<RenderProps> for LibraryCollectionsView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 // we want this to be rendered like a normal tree, not a check tree, so we don't show the checkboxes
                 .node_unchecked_symbol("▪ ")
                 .node_checked_symbol("▪ ")

--- a/tui/src/ui/components/content_view/views/dynamic.rs
+++ b/tui/src/ui/components/content_view/views/dynamic.rs
@@ -323,7 +323,7 @@ impl ComponentRender<RenderProps> for DynamicView {
                             "checked items"
                         },
                     )
-                    .fg(TEXT_HIGHLIGHT),
+                    .fg(*TEXT_HIGHLIGHT),
                 ]))
                 .italic()
                 .border_style(border_style);
@@ -353,7 +353,7 @@ impl ComponentRender<RenderProps> for DynamicView {
             frame.render_stateful_widget(
                 CheckTree::new(&items)
                     .unwrap()
-                    .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                    .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                     .experimental_scrollbar(Some(Scrollbar::new(
                         ScrollbarOrientation::VerticalRight,
                     ))),
@@ -365,7 +365,7 @@ impl ComponentRender<RenderProps> for DynamicView {
 
             frame.render_widget(
                 Line::from(text)
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -651,15 +651,15 @@ impl ComponentRender<RenderProps> for LibraryDynamicView {
             let [input_box_area, query_builder_area, content_area] = lib_split_area(content_area);
 
             let (name_text_color, query_text_color) = match self.focus {
-                Focus::NameInput => (TEXT_HIGHLIGHT_ALT.into(), TEXT_HIGHLIGHT.into()),
-                Focus::QueryInput => (TEXT_HIGHLIGHT.into(), TEXT_HIGHLIGHT_ALT.into()),
-                Focus::Tree => (TEXT_NORMAL.into(), TEXT_NORMAL.into()),
+                Focus::NameInput => ((*TEXT_HIGHLIGHT_ALT).into(), (*TEXT_HIGHLIGHT).into()),
+                Focus::QueryInput => ((*TEXT_HIGHLIGHT).into(), (*TEXT_HIGHLIGHT_ALT).into()),
+                Focus::Tree => ((*TEXT_NORMAL).into(), (*TEXT_NORMAL).into()),
             };
 
             let (name_border_color, query_border_color) = match self.focus {
-                Focus::NameInput => (BORDER_FOCUSED.into(), BORDER_UNFOCUSED.into()),
-                Focus::QueryInput => (BORDER_UNFOCUSED.into(), BORDER_FOCUSED.into()),
-                Focus::Tree => (BORDER_UNFOCUSED.into(), BORDER_UNFOCUSED.into()),
+                Focus::NameInput => ((*BORDER_FOCUSED).into(), (*BORDER_UNFOCUSED).into()),
+                Focus::QueryInput => ((*BORDER_UNFOCUSED).into(), (*BORDER_FOCUSED).into()),
+                Focus::Tree => ((*BORDER_UNFOCUSED).into(), (*BORDER_UNFOCUSED).into()),
             };
 
             let (name_show_cursor, query_show_cursor) = match self.focus {
@@ -694,7 +694,7 @@ impl ComponentRender<RenderProps> for LibraryDynamicView {
             } else {
                 input_box::RenderProps {
                     area: query_builder_area,
-                    text_color: TEXT_HIGHLIGHT.into(),
+                    text_color: (*TEXT_HIGHLIGHT).into(),
                     border: Block::bordered()
                         .title("Invalid Query:")
                         .border_style(Style::default().fg(query_border_color)),
@@ -734,7 +734,7 @@ impl ComponentRender<RenderProps> for LibraryDynamicView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 // we want this to be rendered like a normal tree, not a check tree, so we don't show the checkboxes
                 .node_unchecked_symbol("▪ ")
                 .node_checked_symbol("▪ ")

--- a/tui/src/ui/components/content_view/views/generic.rs
+++ b/tui/src/ui/components/content_view/views/generic.rs
@@ -206,7 +206,7 @@ where
                             "checked items"
                         },
                     )
-                    .fg(TEXT_HIGHLIGHT),
+                    .fg(*TEXT_HIGHLIGHT),
                 ]))
                 .italic()
                 .border_style(border_style);
@@ -229,7 +229,7 @@ where
 
             frame.render_widget(
                 Line::from(text)
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -243,7 +243,7 @@ where
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold()),
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold()),
             props.area,
             &mut self.tree_state.lock().unwrap(),
         );

--- a/tui/src/ui/components/content_view/views/none.rs
+++ b/tui/src/ui/components/content_view/views/none.rs
@@ -58,7 +58,7 @@ impl ComponentRender<RenderProps> for NoneView {
 
         frame.render_widget(
             Line::from(text)
-                .style(Style::default().fg(TEXT_NORMAL.into()))
+                .style(Style::default().fg((*TEXT_NORMAL).into()))
                 .alignment(Alignment::Center),
             props.area,
         );

--- a/tui/src/ui/components/content_view/views/playlist.rs
+++ b/tui/src/ui/components/content_view/views/playlist.rs
@@ -305,7 +305,7 @@ impl ComponentRender<RenderProps> for PlaylistView {
                             "checked items"
                         },
                     )
-                    .fg(TEXT_HIGHLIGHT),
+                    .fg(*TEXT_HIGHLIGHT),
                 ]))
                 .italic()
                 .border_style(border_style);
@@ -328,7 +328,7 @@ impl ComponentRender<RenderProps> for PlaylistView {
 
             frame.render_widget(
                 Line::from(text)
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -346,7 +346,7 @@ impl ComponentRender<RenderProps> for PlaylistView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             props.area,
             &mut self.tree_state.lock().unwrap(),
@@ -596,10 +596,10 @@ impl ComponentRender<RenderProps> for LibraryPlaylistsView {
                 frame,
                 input_box::RenderProps {
                     area: input_box_area,
-                    text_color: TEXT_HIGHLIGHT_ALT.into(),
+                    text_color: (*TEXT_HIGHLIGHT_ALT).into(),
                     border: Block::bordered()
                         .title("Enter Name:")
-                        .border_style(Style::default().fg(BORDER_FOCUSED.into())),
+                        .border_style(Style::default().fg((*BORDER_FOCUSED).into())),
                     show_cursor: self.input_box_visible,
                 },
             );
@@ -637,7 +637,7 @@ impl ComponentRender<RenderProps> for LibraryPlaylistsView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 // we want this to be rendered like a normal tree, not a check tree, so we don't show the checkboxes
                 .node_unchecked_symbol("▪ ")
                 .node_checked_symbol("▪ ")

--- a/tui/src/ui/components/content_view/views/radio.rs
+++ b/tui/src/ui/components/content_view/views/radio.rs
@@ -211,7 +211,7 @@ impl ComponentRender<RenderProps> for RadioView {
                             "checked items"
                         },
                     )
-                    .fg(TEXT_HIGHLIGHT),
+                    .fg(*TEXT_HIGHLIGHT),
                 ]))
                 .italic()
                 .border_style(border_style);
@@ -241,7 +241,7 @@ impl ComponentRender<RenderProps> for RadioView {
             frame.render_stateful_widget(
                 CheckTree::new(&items)
                     .unwrap()
-                    .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                    .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                     .experimental_scrollbar(Some(Scrollbar::new(
                         ScrollbarOrientation::VerticalRight,
                     ))),
@@ -253,7 +253,7 @@ impl ComponentRender<RenderProps> for RadioView {
 
             frame.render_widget(
                 Line::from(text)
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );

--- a/tui/src/ui/components/content_view/views/random.rs
+++ b/tui/src/ui/components/content_view/views/random.rs
@@ -184,7 +184,7 @@ impl ComponentRender<RenderProps> for RandomView {
         if self.props.is_none() {
             frame.render_widget(
                 Line::from("Random items unavailable")
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -195,14 +195,14 @@ impl ComponentRender<RenderProps> for RandomView {
             .iter()
             .map(|item| {
                 ListItem::new(
-                    Span::styled(item.to_string(), Style::default().fg(TEXT_NORMAL.into()))
+                    Span::styled(item.to_string(), Style::default().fg((*TEXT_NORMAL).into()))
                         .into_centered_line(),
                 )
             })
             .collect::<Vec<_>>();
 
         frame.render_stateful_widget(
-            List::new(items).highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold()),
+            List::new(items).highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold()),
             props.area,
             &mut self.random_type_list.clone(),
         );

--- a/tui/src/ui/components/content_view/views/search.rs
+++ b/tui/src/ui/components/content_view/views/search.rs
@@ -252,9 +252,9 @@ impl ComponentRender<RenderProps> for SearchView {
             input_box::RenderProps {
                 area: search_bar_area,
                 text_color: if self.search_bar_focused {
-                    TEXT_HIGHLIGHT_ALT.into()
+                    (*TEXT_HIGHLIGHT_ALT).into()
                 } else {
-                    TEXT_NORMAL.into()
+                    (*TEXT_NORMAL).into()
                 },
                 border: Block::bordered().title("Search").border_style(
                     Style::default()
@@ -314,7 +314,7 @@ impl ComponentRender<RenderProps> for SearchView {
         if self.props.search_results.is_empty() {
             frame.render_widget(
                 Line::from("No results found")
-                    .style(Style::default().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().fg((*TEXT_NORMAL).into()))
                     .alignment(Alignment::Center),
                 props.area,
             );
@@ -331,7 +331,7 @@ impl ComponentRender<RenderProps> for SearchView {
         frame.render_stateful_widget(
             CheckTree::new(items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             props.area,
             &mut self.tree_state.lock().unwrap(),

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -241,7 +241,7 @@ impl ComponentRender<RenderProps> for LibrarySongsView {
         frame.render_stateful_widget(
             CheckTree::new(&items)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 .experimental_scrollbar(Some(Scrollbar::new(ScrollbarOrientation::VerticalRight))),
             props.area,
             &mut self.tree_state.lock().unwrap(),

--- a/tui/src/ui/components/control_panel.rs
+++ b/tui/src/ui/components/control_panel.rs
@@ -342,19 +342,19 @@ impl ComponentRender<RenderProps> for ControlPanel {
         let song_info_widget = self.props.song_title.clone().map_or_else(
             || {
                 Line::from("No Song Playing")
-                    .style(Style::default().bold().fg(TEXT_NORMAL.into()))
+                    .style(Style::default().bold().fg((*TEXT_NORMAL).into()))
                     .centered()
             },
             |song_title| {
                 Line::from(vec![
                     Span::styled(
                         song_title,
-                        Style::default().bold().fg(TEXT_HIGHLIGHT_ALT.into()),
+                        Style::default().bold().fg((*TEXT_HIGHLIGHT_ALT).into()),
                     ),
                     Span::raw("   "),
                     Span::styled(
                         self.props.song_artist.clone().unwrap_or_default(),
-                        Style::default().italic().fg(TEXT_NORMAL.into()),
+                        Style::default().italic().fg((*TEXT_NORMAL).into()),
                     ),
                 ])
                 .centered()
@@ -381,8 +381,8 @@ impl ComponentRender<RenderProps> for ControlPanel {
         frame.render_widget(
             LineGauge::default()
                 .label(Line::from(runtime_string(self.props.song_runtime)))
-                .filled_style(Style::default().fg(GAUGE_FILLED.into()).bold())
-                .unfilled_style(Style::default().fg(GAUGE_UNFILLED.into()).bold())
+                .filled_style(Style::default().fg((*GAUGE_FILLED).into()).bold())
+                .unfilled_style(Style::default().fg((*GAUGE_UNFILLED).into()).bold())
                 .ratio(self.props.song_runtime.map_or(0.0, |runtime| {
                     (runtime.seek_position.as_secs_f64() / runtime.duration.as_secs_f64())
                         .clamp(0.0, 1.0)
@@ -394,7 +394,7 @@ impl ComponentRender<RenderProps> for ControlPanel {
         frame.render_widget(
             // muted icon if muted, otherwise a volume icon.
             Line::from(volume_string(self.props.muted, self.props.volume))
-                .style(Style::default().bold().fg(TEXT_NORMAL.into()))
+                .style(Style::default().bold().fg((*TEXT_NORMAL).into()))
                 .alignment(Alignment::Left),
             volume,
         );

--- a/tui/src/ui/components/queuebar.rs
+++ b/tui/src/ui/components/queuebar.rs
@@ -238,7 +238,7 @@ impl ComponentRender<RenderProps> for QueueBar {
         );
         frame.render_widget(
             Paragraph::new(queue_info)
-                .style(Style::default().fg(TEXT_NORMAL.into()))
+                .style(Style::default().fg((*TEXT_NORMAL).into()))
                 .alignment(ratatui::layout::Alignment::Center),
             info_area,
         );
@@ -250,7 +250,7 @@ impl ComponentRender<RenderProps> for QueueBar {
                 Line::from("\u{23CE} : Select | d: Delete"),
                 Line::from("s: Shuffle | r: Repeat"),
             ]))
-            .style(Style::default().fg(TEXT_NORMAL.into()))
+            .style(Style::default().fg((*TEXT_NORMAL).into()))
             .alignment(ratatui::layout::Alignment::Center),
             instructions_area,
         );
@@ -270,9 +270,9 @@ impl ComponentRender<RenderProps> for QueueBar {
             .enumerate()
             .map(|(index, song)| {
                 let style = if Some(index) == self.props.current_position {
-                    Style::default().fg(TEXT_HIGHLIGHT_ALT.into())
+                    Style::default().fg((*TEXT_HIGHLIGHT_ALT).into())
                 } else {
-                    Style::default().fg(TEXT_NORMAL.into())
+                    Style::default().fg((*TEXT_NORMAL).into())
                 };
 
                 ListItem::new(song.title.as_str()).style(style)
@@ -283,7 +283,7 @@ impl ComponentRender<RenderProps> for QueueBar {
             List::new(items)
                 .highlight_style(
                     Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
+                        .fg((*TEXT_HIGHLIGHT).into())
                         .add_modifier(Modifier::BOLD),
                 )
                 .scroll_padding(1)

--- a/tui/src/ui/components/sidebar.rs
+++ b/tui/src/ui/components/sidebar.rs
@@ -246,7 +246,7 @@ impl ComponentRender<RenderProps> for Sidebar {
             .map(|item| {
                 ListItem::new(Span::styled(
                     item.to_string(),
-                    Style::default().fg(TEXT_NORMAL.into()),
+                    Style::default().fg((*TEXT_NORMAL).into()),
                 ))
             })
             .collect::<Vec<_>>();
@@ -255,7 +255,7 @@ impl ComponentRender<RenderProps> for Sidebar {
             List::new(items)
                 .highlight_style(
                     Style::default()
-                        .fg(TEXT_HIGHLIGHT.into())
+                        .fg((*TEXT_HIGHLIGHT).into())
                         .add_modifier(Modifier::BOLD),
                 )
                 .direction(ratatui::widgets::ListDirection::TopToBottom),

--- a/tui/src/ui/widgets/popups/dynamic.rs
+++ b/tui/src/ui/widgets/popups/dynamic.rs
@@ -203,12 +203,12 @@ impl ComponentRender<Rect> for DynamicPlaylistEditor {
         let [name_area, query_area] = split_area(area, 3, 3);
 
         let (name_color, query_color) = match self.focus {
-            Focus::Name => (TEXT_HIGHLIGHT_ALT.into(), TEXT_NORMAL.into()),
-            Focus::Query => (TEXT_NORMAL.into(), TEXT_HIGHLIGHT_ALT.into()),
+            Focus::Name => ((*TEXT_HIGHLIGHT_ALT).into(), (*TEXT_NORMAL).into()),
+            Focus::Query => ((*TEXT_NORMAL).into(), (*TEXT_HIGHLIGHT_ALT).into()),
         };
         let (name_border, query_border) = match self.focus {
-            Focus::Name => (BORDER_FOCUSED.into(), BORDER_UNFOCUSED.into()),
-            Focus::Query => (BORDER_UNFOCUSED.into(), BORDER_FOCUSED.into()),
+            Focus::Name => ((*BORDER_FOCUSED).into(), (*BORDER_UNFOCUSED).into()),
+            Focus::Query => ((*BORDER_UNFOCUSED).into(), (*BORDER_FOCUSED).into()),
         };
 
         self.name_input.render(
@@ -243,7 +243,7 @@ impl ComponentRender<Rect> for DynamicPlaylistEditor {
                         .title("Invalid Query:")
                         .border_style(Style::default().fg(query_border)),
                     area: query_area,
-                    text_color: TEXT_HIGHLIGHT.into(),
+                    text_color: (*TEXT_HIGHLIGHT).into(),
                     show_cursor: self.focus == Focus::Query,
                 },
             );

--- a/tui/src/ui/widgets/popups/mod.rs
+++ b/tui/src/ui/widgets/popups/mod.rs
@@ -26,7 +26,7 @@ pub trait Popup: for<'a> ComponentRender<Rect> + Send + Sync {
 
     /// override this method to change the border color of the popup
     fn border_color(&self) -> Color {
-        POPUP_BORDER.into()
+        (*POPUP_BORDER).into()
     }
 
     fn update_with_state(&mut self, state: &AppState);

--- a/tui/src/ui/widgets/popups/playlist.rs
+++ b/tui/src/ui/widgets/popups/playlist.rs
@@ -276,10 +276,10 @@ impl ComponentRender<Rect> for PlaylistSelector {
                 frame,
                 RenderProps {
                     area: input_box_area,
-                    text_color: TEXT_HIGHLIGHT_ALT.into(),
+                    text_color: (*TEXT_HIGHLIGHT_ALT).into(),
                     border: Block::bordered()
                         .title("Enter Name:")
-                        .border_style(Style::default().fg(BORDER_FOCUSED.into())),
+                        .border_style(Style::default().fg((*BORDER_FOCUSED).into())),
                     show_cursor: self.input_box_visible,
                 },
             );
@@ -315,7 +315,7 @@ impl ComponentRender<Rect> for PlaylistSelector {
         frame.render_stateful_widget(
             CheckTree::new(&playlists)
                 .unwrap()
-                .highlight_style(Style::default().fg(TEXT_HIGHLIGHT.into()).bold())
+                .highlight_style(Style::default().fg((*TEXT_HIGHLIGHT).into()).bold())
                 // we want this to be rendered like a normal tree, not a check tree, so we don't show the checkboxes
                 .node_unchecked_symbol("▪ ")
                 .node_checked_symbol("▪ ")
@@ -430,10 +430,10 @@ impl ComponentRender<Rect> for PlaylistEditor {
             frame,
             RenderProps {
                 area,
-                text_color: TEXT_HIGHLIGHT_ALT.into(),
+                text_color: (*TEXT_HIGHLIGHT_ALT).into(),
                 border: Block::bordered()
                     .title("Enter Name:")
-                    .border_style(Style::default().fg(BORDER_FOCUSED.into())),
+                    .border_style(Style::default().fg((*BORDER_FOCUSED).into())),
                 show_cursor: true,
             },
         );


### PR DESCRIPTION
closes #328 

## mecomp is now rice-able!

### An example using pywal to theme the player

![image](https://github.com/user-attachments/assets/e0a95a14-ee2f-4f7b-b8c3-6eb6a7cedb01)