### PR TITLE
fix(daemon): issue where interrupt receiver could lag

### DIFF
--- a/daemon/src/termination.rs
+++ b/daemon/src/termination.rs
@@ -219,7 +219,7 @@ async fn terminate_by_signal(terminator: Terminator) {
 #[must_use]
 #[inline]
 pub fn create_termination() -> (Terminator, InterruptReceiver) {
-    let (tx, rx) = broadcast::channel(1);
+    let (tx, rx) = broadcast::channel(2);
     let terminator = Terminator::new(tx);
     let interrupt = InterruptReceiver::new(rx);
 


### PR DESCRIPTION
technically wasn't really a problem, since the error gets handled the same way a success would be, but I like not having unnecessary errors getting logged