### PR TITLE
fix(tui): adjust mouse hitboxes for misaligned components

### DIFF
--- a/tui/src/ui/components/control_panel.rs
+++ b/tui/src/ui/components/control_panel.rs
@@ -158,6 +158,14 @@ impl Component for ControlPanel {
         } = mouse;
         let mouse_position = Position::new(column, row);
 
+        if kind == MouseEventKind::Down(MouseButton::Left) && area.contains(mouse_position) {
+            self.action_tx
+                .send(Action::ActiveComponent(ComponentAction::Set(
+                    ActiveComponent::ControlPanel,
+                )))
+                .unwrap();
+        }
+
         // adjust area to exclude the border
         let area = Rect {
             y: area.y + 1,
@@ -193,14 +201,6 @@ impl Component for ControlPanel {
                 .unwrap_or(u16::MAX),
             ..volume
         };
-
-        if kind == MouseEventKind::Down(MouseButton::Left) && area.contains(mouse_position) {
-            self.action_tx
-                .send(Action::ActiveComponent(ComponentAction::Set(
-                    ActiveComponent::ControlPanel,
-                )))
-                .unwrap();
-        }
 
         match kind {
             MouseEventKind::Down(MouseButton::Left) if play_pause.contains(mouse_position) => {

--- a/tui/src/ui/components/sidebar.rs
+++ b/tui/src/ui/components/sidebar.rs
@@ -187,19 +187,20 @@ impl Component for Sidebar {
         } = mouse;
         let mouse_position = Position::new(column, row);
 
+        if kind == MouseEventKind::Down(MouseButton::Left) && area.contains(mouse_position) {
+            self.action_tx
+                .send(Action::ActiveComponent(ComponentAction::Set(
+                    ActiveComponent::Sidebar,
+                )))
+                .unwrap();
+        }
+
         // adjust area to exclude the border
         let area = area.inner(Margin::new(1, 1));
 
         match kind {
             // TODO: refactor Sidebar to use a CheckTree for better mouse handling
             MouseEventKind::Down(MouseButton::Left) if area.contains(mouse_position) => {
-                // make this the active component
-                self.action_tx
-                    .send(Action::ActiveComponent(ComponentAction::Set(
-                        ActiveComponent::Sidebar,
-                    )))
-                    .unwrap();
-
                 // adjust the mouse position so that it is relative to the area of the list
                 let adjusted_mouse_y = mouse_position.y - area.y;
 


### PR DESCRIPTION
fixes #331

basic idea, change focus *before* excluding the border from the hitbox area