### PR TITLE
feat(tui): overhaul click handling for checktree's

### DIFF
--- a/tui/src/ui/colors.rs
+++ b/tui/src/ui/colors.rs
@@ -199,28 +199,6 @@ pub mod material {
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use pretty_assertions::assert_eq;
-        use rstest::rstest;
-
-        #[rstest]
-        #[case::valid_hex(Some(HexColor("#ff0000")), "#ff0000")]
-        #[case::valid_name(Some(RED_500), "red_500")]
-        #[case::invalid_name(None, "red_5")]
-        #[case::invalid_hex(None, "#ff00g0")]
-        #[case::invalid_hex_no_hash(None, "ff0000")]
-        #[case::invalid_hex_too_short(None, "#ff00")]
-        #[case::invalid_hex_too_long(None, "#ff00000")]
-        #[case::invalid_hex_no_hash_too_short(None, "ff00")]
-        #[case::invalid_hex_no_hash_too_long(None, "ff00000")]
-        fn test_parse(#[case] expected: Option<HexColor>, #[case] input: &'static str) {
-            let actual = HexColor::parse(input);
-            assert_eq!(actual, expected);
-        }
-    }
-
     /// a lookup table for the colors
     static MATERIAL_COLORS: &[(&str, HexColor)] = &[
         // reds
@@ -1032,4 +1010,26 @@ pub mod material {
     pub const BLACK: HexColor = HexColor("#000000");
     /// <span style="color:#ffffff">&#9632;</span> (#ffffff)
     pub const WHITE: HexColor = HexColor("#ffffff");
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case::valid_hex(Some(HexColor("#ff0000")), "#ff0000")]
+        #[case::valid_name(Some(RED_500), "red_500")]
+        #[case::invalid_name(None, "red_5")]
+        #[case::invalid_hex(None, "#ff00g0")]
+        #[case::invalid_hex_no_hash(None, "ff0000")]
+        #[case::invalid_hex_too_short(None, "#ff00")]
+        #[case::invalid_hex_too_long(None, "#ff00000")]
+        #[case::invalid_hex_no_hash_too_short(None, "ff00")]
+        #[case::invalid_hex_no_hash_too_long(None, "ff00000")]
+        fn test_parse(#[case] expected: Option<HexColor>, #[case] input: &'static str) {
+            let actual = HexColor::parse(input);
+            assert_eq!(actual, expected);
+        }
+    }
 }

--- a/tui/src/ui/components/content_view/views/album.rs
+++ b/tui/src/ui/components/content_view/views/album.rs
@@ -183,7 +183,7 @@ impl Component for LibraryAlbumsView {
             .tree_state
             .lock()
             .unwrap()
-            .handle_mouse_event(mouse, area);
+            .handle_mouse_event(mouse, area, false);
         if let Some(action) = result {
             self.action_tx.send(action).unwrap();
         }
@@ -643,10 +643,6 @@ mod item_view_tests {
             },
             area,
         );
-        assert_eq!(
-            rx.blocking_recv().unwrap(),
-            Action::ActiveView(ViewAction::Set(ActiveView::Artist(item_id())))
-        );
         let buffer = terminal
             .draw(|frame| view.render(frame, props))
             .unwrap()
@@ -664,6 +660,22 @@ mod item_view_tests {
             "└ ⏎ : Open | ←/↑/↓/→: Navigate | ␣ Check───────────────────┘",
         ]);
         assert_buffer_eq(&buffer, &expected);
+        // ctrl click on it
+        for _ in 0..2 {
+            view.handle_mouse_event(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 2,
+                    row: 7,
+                    modifiers: KeyModifiers::CONTROL,
+                },
+                area,
+            );
+            assert_eq!(
+                rx.blocking_recv().unwrap(),
+                Action::ActiveView(ViewAction::Set(ActiveView::Artist(item_id())))
+            );
+        }
 
         // scroll up
         view.handle_mouse_event(
@@ -967,13 +979,13 @@ mod library_view_tests {
             .clone();
         assert_buffer_eq(&buffer, &expected);
 
-        // click down on selected item
+        // ctrl click on an item
         view.handle_mouse_event(
             MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: 2,
                 row: 2,
-                modifiers: KeyModifiers::empty(),
+                modifiers: KeyModifiers::CONTROL,
             },
             area,
         );

--- a/tui/src/ui/components/content_view/views/artist.rs
+++ b/tui/src/ui/components/content_view/views/artist.rs
@@ -182,7 +182,7 @@ impl Component for LibraryArtistsView {
             .tree_state
             .lock()
             .unwrap()
-            .handle_mouse_event(mouse, area);
+            .handle_mouse_event(mouse, area, false);
         if let Some(action) = result {
             self.action_tx.send(action).unwrap();
         }
@@ -618,10 +618,6 @@ mod item_view_tests {
             },
             area,
         );
-        assert_eq!(
-            rx.blocking_recv().unwrap(),
-            Action::ActiveView(ViewAction::Set(ActiveView::Album(item_id())))
-        );
         let buffer = terminal
             .draw(|frame| view.render(frame, props))
             .unwrap()
@@ -639,6 +635,22 @@ mod item_view_tests {
             "└ ⏎ : Open | ←/↑/↓/→: Navigate | ␣ Check───────────────────┘",
         ]);
         assert_buffer_eq(&buffer, &expected);
+        // crtl click on it
+        for _ in 0..2 {
+            view.handle_mouse_event(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 2,
+                    row: 7,
+                    modifiers: KeyModifiers::CONTROL,
+                },
+                area,
+            );
+            assert_eq!(
+                rx.blocking_recv().unwrap(),
+                Action::ActiveView(ViewAction::Set(ActiveView::Album(item_id())))
+            );
+        }
 
         // scroll up
         view.handle_mouse_event(
@@ -934,13 +946,13 @@ mod library_view_tests {
             .clone();
         assert_buffer_eq(&buffer, &expected);
 
-        // click down on selected item
+        // ctrl click down on selected item
         view.handle_mouse_event(
             MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: 2,
                 row: 2,
-                modifiers: KeyModifiers::empty(),
+                modifiers: KeyModifiers::CONTROL,
             },
             area,
         );

--- a/tui/src/ui/components/content_view/views/generic.rs
+++ b/tui/src/ui/components/content_view/views/generic.rs
@@ -151,7 +151,7 @@ where
             .tree_state
             .lock()
             .unwrap()
-            .handle_mouse_event(mouse, content_area);
+            .handle_mouse_event(mouse, content_area, false);
         if let Some(action) = result {
             self.action_tx.send(action).unwrap();
         }

--- a/tui/src/ui/components/content_view/views/search.rs
+++ b/tui/src/ui/components/content_view/views/search.rs
@@ -223,11 +223,11 @@ impl Component for SearchView {
                     height: content_area.height.saturating_sub(2),
                 };
 
-                let result = self
-                    .tree_state
-                    .lock()
-                    .unwrap()
-                    .handle_mouse_event(mouse, content_area);
+                let result =
+                    self.tree_state
+                        .lock()
+                        .unwrap()
+                        .handle_mouse_event(mouse, content_area, false);
                 if let Some(action) = result {
                     self.action_tx.send(action).unwrap();
                 }
@@ -816,13 +816,13 @@ mod tests {
             area,
         );
 
-        // click on the selected item
+        // ctrl-click
         view.handle_mouse_event(
             MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: 2,
                 row: 5,
-                modifiers: KeyModifiers::empty(),
+                modifiers: KeyModifiers::CONTROL,
             },
             area,
         );

--- a/tui/src/ui/components/content_view/views/song.rs
+++ b/tui/src/ui/components/content_view/views/song.rs
@@ -181,7 +181,7 @@ impl Component for LibrarySongsView {
             .tree_state
             .lock()
             .unwrap()
-            .handle_mouse_event(mouse, area);
+            .handle_mouse_event(mouse, area, false);
         if let Some(action) = result {
             self.action_tx.send(action).unwrap();
         }
@@ -797,10 +797,6 @@ mod item_view_tests {
             },
             area,
         );
-        assert_eq!(
-            rx.blocking_recv().unwrap(),
-            Action::ActiveView(ViewAction::Set(ActiveView::Artist(item_id())))
-        );
         let buffer = terminal
             .draw(|frame| view.render(frame, props))
             .unwrap()
@@ -818,6 +814,22 @@ mod item_view_tests {
             "└ ⏎ : Open | ←/↑/↓/→: Navigate | ␣ Check───────────────────┘",
         ]);
         assert_buffer_eq(&buffer, &expected);
+        // ctrl click on it
+        for _ in 0..2 {
+            view.handle_mouse_event(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 2,
+                    row: 7,
+                    modifiers: KeyModifiers::CONTROL,
+                },
+                area,
+            );
+            assert_eq!(
+                rx.blocking_recv().unwrap(),
+                Action::ActiveView(ViewAction::Set(ActiveView::Artist(item_id())))
+            );
+        }
 
         // scroll up
         view.handle_mouse_event(
@@ -1130,13 +1142,13 @@ mod library_view_tests {
             .clone();
         assert_buffer_eq(&buffer, &expected);
 
-        // click down on selected item
+        // ctrl-click down on selected item
         view.handle_mouse_event(
             MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: 2,
                 row: 2,
-                modifiers: KeyModifiers::empty(),
+                modifiers: KeyModifiers::CONTROL,
             },
             area,
         );


### PR DESCRIPTION
For most views:
- clicking will now only toggle the open/checked state of the item, and not open it.
- ctrl-clicking will open the clicked item

this allows users to quickly toggle items without accidentally navigating away from the current view

For some views (e.g. library dynamic, library playlist, library collection), where we use the checktree to mimic a standard list, we set `swap_ctrl_click_behavior` to `true` so that ctrl-clicking will toggle the open/checked state of the item, and clicking will open it.
- this retains the previous behavior of such views.