### PR TITLE
fix(storage): compilation error when db feature not enabled

### DIFF
--- a/storage/src/errors.rs
+++ b/storage/src/errors.rs
@@ -19,6 +19,7 @@ pub enum Error {
     NotCreated,
 }
 
+#[cfg(feature = "db")]
 impl From<surrealdb::Error> for Error {
     #[inline]
     fn from(err: surrealdb::Error) -> Self {


### PR DESCRIPTION
fixes the issue that caused the release of v0.5.4 to crates.io to fail